### PR TITLE
Add production notifier starter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # This value is intentionally synthetic and safe only for a local tutorial.
 # Use a secret manager and at least 32 random bytes in a real environment.
 SESSION_SECRET=local-tutorial-secret-change-before-production
+AUTH_MODE=anonymous
 PUBLIC_ORIGIN=http://localhost:3000
 HOST=127.0.0.1
 PORT=3000
@@ -10,3 +11,21 @@ QUEUE_NAME=notifier-demo
 EVENT_CHANNEL=notifier-demo:events
 TASK_DELAY_MS=1200
 WORKER_CONCURRENCY=4
+TASK_RETENTION_SECONDS=86400
+TASK_RATE_LIMIT=30
+TASK_RATE_WINDOW_SECONDS=60
+REPLAY_LIMIT=50
+
+# Production requires AUTH_MODE=oidc, HTTPS, and an ACL-authenticated TLS Redis
+# URL. Mount certificate files as secrets when a private CA or mutual TLS is
+# required; do not commit tokens, passwords, keys, or certificates.
+# AUTH_MODE=oidc
+# OIDC_ISSUER=https://identity.example/
+# OIDC_AUDIENCE=https://notifier.example/api
+# OIDC_JWKS_URL=https://identity.example/.well-known/jwks.json
+# OIDC_ALGORITHMS=RS256
+# OIDC_TENANT_CLAIM=tenant_id
+# REDIS_URL=rediss://notifier-user:password@redis.example:6380/0
+# REDIS_CA_FILE=/run/secrets/redis-ca.pem
+# REDIS_CERT_FILE=/run/secrets/redis-client.pem
+# REDIS_KEY_FILE=/run/secrets/redis-client-key.pem

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Node 24
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    services:
+      redis:
+        image: redis:8.2.8-alpine@sha256:a7859ed111db3c1f5404a973a4747505d559fb5ca32d37e447afc0ef845a2103
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 3s
+          --health-timeout 2s
+          --health-retries 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - name: Install exact dependencies
+        run: npm ci
+      - name: Audit production dependencies
+        run: npm audit --omit=dev --audit-level=high
+      - name: Run unit and integration tests
+        run: npm run test:all
+        env:
+          TEST_REDIS_URL: redis://127.0.0.1:6379

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # Sample Notifier Service
 
+[![CI](https://github.com/pulkitsinghal/sample-notifier-service/actions/workflows/ci.yml/badge.svg)](https://github.com/pulkitsinghal/sample-notifier-service/actions/workflows/ci.yml)
+
 A modern tutorial for a durable background-job notification pattern:
 
 1. a browser asks an API to start work;
 2. the API returns immediately with a task ID;
 3. a separate worker processes the durable job;
 4. Socket.IO provides a fast, targeted update; and
-5. the browser reads saved task state after a reload or missed event.
+5. the browser reads saved task state after a reload or missed event; and
+6. the user explicitly acknowledges a terminal notification.
 
 The original 2016 demo made this flow unusually easy to see. This replacement
 keeps that teaching intent while fixing its clean-clone, authentication,
@@ -45,13 +48,14 @@ paid service.
 | Runtime | EOL Node 4, Redis 2.8, legacy Compose v2 | Node 24 LTS, pinned packages and images, current Compose Specification |
 | Clean start | Dockerfiles did not install dependencies | Multi-stage image uses `npm ci` and a lockfile |
 | Job delivery | Redis Pub/Sub could lose work while the worker was offline | BullMQ keeps jobs in Redis and retries failures with backoff |
-| Browser delivery | Result existed only as a socket event | Socket event is a fast hint; `GET /api/tasks/:id` is the recoverable truth |
-| Identity | Socket ID was treated as a short-lived password | Signed HttpOnly session cookie maps to a server-only notification room |
+| Browser delivery | Result existed only as a socket event | Socket event is a fast hint; recent task state and acknowledgement are durable |
+| Identity | Socket ID was treated as a short-lived password | Local signed sessions; production JWT access tokens validated by issuer, audience, algorithm, expiry, tenant, and subject |
+| Redelivery | Refresh produced an unrelated delivery target | Unacknowledged terminal tasks replay when the same identity reconnects |
 | Internal notify API | Public, unauthenticated `/notify` endpoint | Worker publishes an internal event; browsers cannot choose the target room |
 | Multiple API instances | Each notifier owned an isolated socket map | Every API replica subscribes to completion events and emits to its local room |
 | Exposure | Redis and notifier ports were published to the host | Only the web API binds to `127.0.0.1`; Redis stays on the container network |
-| Safety | No validation, security headers, health checks, or graceful stop | Bounded JSON, exact-origin writes, Helmet CSP, health endpoints, shutdown handlers |
-| Verification | Test scripts intentionally failed | Unit tests plus a two-API/one-worker Redis integration test |
+| Safety | No validation, security headers, limits, health checks, or graceful stop | Bounded JSON, exact-origin writes, Redis-backed per-identity limits, Helmet CSP, health endpoints, shutdown handlers |
+| Verification | Test scripts intentionally failed | Unit and Redis integration suites locally, in Compose, and in GitHub Actions |
 
 See [the architectural analysis](docs/architecture.md) for the evidence and
 tradeoffs behind each change.
@@ -65,17 +69,19 @@ sequenceDiagram
     participant Q as Redis and BullMQ
     participant W as Worker
 
-    B->>A: GET / (signed HttpOnly session)
+    B->>A: Local signed session or production access token
     B->>A: POST /api/tasks
-    A->>Q: Add durable job with server-derived room
+    A->>Q: Rate limit identity; index and add durable job
     A-->>B: 202 Accepted and taskId
     Q->>W: Claim job
     W->>Q: Save completion and publish live hint
     Q-->>A: Fan out task update to every API replica
     A-->>B: Socket.IO task:update
     B->>A: GET /api/tasks/:taskId
-    A->>Q: Read durable state and verify owner room
+    A->>Q: Read durable state and verify identity owner
     A-->>B: Authoritative task state
+    B->>A: POST /api/tasks/:taskId/ack
+    A->>Q: Save idempotent acknowledgement
 ```
 
 The queue and saved result carry the reliability requirement. Redis Pub/Sub
@@ -90,8 +96,9 @@ The [guided tutorial](docs/tutorial.md) walks through:
 - a worker outage;
 - a browser disconnect and result recovery;
 - the cross-instance integration test;
+- explicit acknowledgement and reconnect replay;
 - the exact security boundary of the anonymous demo session; and
-- production decisions intentionally left out of a local sample.
+- the provider-neutral production identity contract.
 
 ## Validate
 
@@ -110,26 +117,33 @@ docker compose --profile test run --build --rm test
 docker compose down
 ```
 
-The integration test starts two API instances, connects the browser client to
-one, submits work to the other, receives the completion event, disconnects,
-then proves that the saved result is still readable.
+The integration suite covers two-API fan-out, durable recovery, retry
+exhaustion, production identity across devices, tenant isolation,
+acknowledgement replay, and distributed rate limiting.
 
-## Tutorial boundary
+## Production starter
 
-This is a local teaching system, not a production deployment template.
+`AUTH_MODE=oidc` turns the API into a provider-neutral authenticated resource
+server. It validates signed JWT access tokens against a configured JWKS,
+derives authorization only from the validated tenant and subject claims, and
+requires production Redis to use `rediss://` with a named ACL user and
+password. Optional CA and mutual-TLS certificate files are supported.
 
-- The checked-in local secret is synthetic. Production must inject a strong
-  secret from a secret manager.
-- `NODE_ENV=production` enables the `Secure` cookie flag, so production also
-  requires HTTPS and a correctly configured reverse proxy.
-- The anonymous session isolates browser tabs for the demo; replace it with
-  real application authentication and authorization for real users.
-- Redis is intentionally not host-published. A production data service still
-  needs network isolation, ACLs, TLS, backups, capacity limits, and monitoring.
+See the [production configuration and operations guide](docs/production.md)
+for the identity contract, client example, Redis ACL/TLS guidance, retention,
+rate-limit and acknowledgement semantics, health behavior, and deployment
+checklist.
+
+This is a production **starter**, not a deployment:
+
+- the checked-in secret, anonymous mode, Redis container, and UI are local-only;
+- production mode is API-only and requires external OIDC login/token acquisition;
+- an operator must supply HTTPS termination, a secret manager, secured Redis,
+  backups, capacity limits, monitoring, and tested recovery;
 - A real worker operation must be idempotent because durable queues can
   redeliver after failures.
-- Task retention, deletion, rate limits, audit logs, and data classification
-  depend on the actual product and cannot be chosen by a generic tutorial.
+- Configurable retention and rate limits are mechanisms, not a product,
+  compliance, or data-classification decision.
 - Redis 8 is tri-licensed. This sample uses its unmodified official image for
   local development; an owner should select and review the applicable Redis
   license before redistribution or product use.
@@ -144,8 +158,14 @@ Design choices were checked against current primary documentation on
 - [Socket.IO delivery guarantees](https://socket.io/docs/v4/delivery-guarantees/)
 - [Socket.IO with multiple nodes](https://socket.io/docs/v4/using-multiple-nodes/)
 - [Redis Pub/Sub delivery semantics](https://redis.io/docs/latest/develop/pubsub/)
+- [Redis security and ACL guidance](https://redis.io/docs/latest/operate/oss_and_stack/management/security/)
+- [Redis TLS](https://redis.io/docs/latest/operate/oss_and_stack/management/security/encryption/)
 - [Redis 8 licensing options](https://redis.io/legal/licenses/)
 - [BullMQ retry behavior](https://docs.bullmq.io/guide/retrying-failing-jobs)
+- [JWT Best Current Practices](https://www.rfc-editor.org/rfc/rfc8725)
+- [`jose` JWT/JWKS documentation](https://github.com/panva/jose)
+- [GitHub Actions Node.js guidance](https://docs.github.com/en/actions/tutorials/build-and-test-code/nodejs)
+- [GitHub Actions service containers](https://docs.github.com/en/actions/tutorials/use-containerized-services/use-docker-service-containers)
 - [Docker Compose Specification](https://docs.docker.com/reference/compose-file/)
 - [Docker build best practices](https://docs.docker.com/build/building/best-practices/)
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,12 +5,17 @@ x-app-environment: &app-environment
   HOST: 0.0.0.0
   PORT: 3000
   PUBLIC_ORIGIN: ${PUBLIC_ORIGIN:-http://localhost:3000}
+  AUTH_MODE: anonymous
   REDIS_URL: redis://redis:6379
   QUEUE_NAME: notifier-demo
   EVENT_CHANNEL: notifier-demo:events
   SESSION_SECRET: ${SESSION_SECRET:-local-tutorial-secret-change-before-production}
   TASK_DELAY_MS: ${TASK_DELAY_MS:-1200}
   WORKER_CONCURRENCY: ${WORKER_CONCURRENCY:-4}
+  TASK_RETENTION_SECONDS: ${TASK_RETENTION_SECONDS:-86400}
+  TASK_RATE_LIMIT: ${TASK_RATE_LIMIT:-30}
+  TASK_RATE_WINDOW_SECONDS: ${TASK_RATE_WINDOW_SECONDS:-60}
+  REPLAY_LIMIT: ${REPLAY_LIMIT:-50}
 
 x-app: &app
   build:
@@ -54,7 +59,7 @@ services:
     command: ["node", "src/start-worker.js"]
 
   redis:
-    image: redis:8.2.8-alpine
+    image: redis:8.2.8-alpine@sha256:a7859ed111db3c1f5404a973a4747505d559fb5ca32d37e447afc0ef845a2103
     command:
       [
         "redis-server",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -82,20 +82,40 @@ at-most-once delivery gaps. The browser therefore treats every socket event as
 a reason to read `GET /api/tasks/:taskId`, and it repeats that read on reconnect
 or page load.
 
-### Stable browser scope without pretending it is user authentication
+### Two explicit identity modes
 
-The API creates a random session identifier, signs it with HMAC-SHA-256, and
-stores it in an HttpOnly, SameSite=Strict cookie. A server-only HMAC-derived
-room is stored in the job. Socket middleware independently verifies the cookie
-and joins that room.
+Local tutorial mode creates a random session identifier, signs it with
+HMAC-SHA-256, and stores it in an HttpOnly, SameSite=Strict cookie.
 
-The browser cannot select a room, a guessed task ID does not grant access, and
-the internal room is removed from public events. Multiple tabs in the same
-anonymous session can receive the same result.
+Production mode accepts JWT access tokens from an external identity provider.
+It pins an asymmetric algorithm allowlist and validates the signature, issuer,
+audience, expiration, subject, and configured tenant claim against a fixed
+JWKS URL. The raw claims are not stored in task data. HMAC-derived owner and
+room keys bind the validated `(tenant, subject)` pair to tasks and sockets.
+The socket is disconnected when its validated token expires.
 
-This is appropriate for a local anonymous lab. A real application must derive
-rooms and task authorization from its authenticated subject and current
-authorization policy.
+In both modes the browser cannot select a room, a guessed task ID does not
+grant access, and the internal room is removed from public events. Production
+devices with refreshed tokens for the same tenant and subject resolve to the
+same owner, while a different tenant or subject receives a non-enumerating
+404.
+
+### Redelivery, acknowledgement, and bounded retention
+
+Each owner has a Redis sorted-set index of recent task IDs. A reconnect reads
+that index and replays terminal tasks without an acknowledgement. The
+authoritative `GET /api/tasks` and `GET /api/tasks/:id` responses still carry
+the task state, so the replay event remains only a wake-up.
+
+`POST /api/tasks/:id/ack` records the first acknowledgement timestamp with
+Redis `SET NX`. Repeating the request returns the same receipt, making the
+operation idempotent. This proves application receipt by an authenticated
+client; it does not prove a human read or acted on the result.
+
+Job state, owner indexes, and acknowledgements share
+`TASK_RETENTION_SECONDS` (24 hours by default, 5 minutes to 30 days allowed).
+Task creation uses a Redis-backed fixed-window limit scoped to the derived
+owner key. The default is 30 tasks per 60 seconds.
 
 ### Horizontal event fan-out
 
@@ -121,6 +141,19 @@ Content Security Policy, and inserts all task text with `textContent`.
 State-changing API requests require the configured exact Origin and bounded
 JSON input.
 
+Production configuration additionally fails closed unless:
+
+- `AUTH_MODE=oidc`;
+- `PUBLIC_ORIGIN` uses HTTPS;
+- the issuer and JWKS URLs use HTTPS;
+- an explicit JWT audience and tenant claim are configured; and
+- Redis uses `rediss://` with an ACL username and password.
+
+Private Redis certificate authorities and mutual-TLS client certificates can
+be mounted read-only and supplied by file path. The application never logs
+connection URLs, credentials, access tokens, certificate contents, or raw
+identity claims.
+
 Redis 8 is available under a choice of RSALv2, SSPLv1, or AGPLv3. The local
 sample pulls the unmodified official image, but selecting a license for
 redistribution or a product deployment remains an owner/legal decision; this
@@ -130,10 +163,14 @@ behalf.
 ## What is intentionally not claimed
 
 - Pub/Sub is not durable and no code calls it durable.
-- A successful socket emit is not proof that a human saw a notification.
+- A successful socket emit is not proof that a client received a notification.
+- A stored acknowledgement proves an authorized client called the endpoint,
+  not that a human saw or acted on the notification.
 - BullMQ retry does not make a non-idempotent business operation safe.
 - A local container test is not evidence of production capacity or failover.
-- The sample has no login, tenant model, regulated-data policy, deployment,
-  cloud secret integration, or paid service.
-- Retaining a recent job for one hour is a tutorial choice, not a universal
-  compliance or product requirement.
+- The sample delegates login, tenant membership, revocation policy, and token
+  issuance to an external provider; it does not implement those systems.
+- The repository has no regulated-data policy, deployment, cloud secret
+  integration, backup schedule, alerting, or paid service.
+- The configurable retention default is not a universal compliance or product
+  requirement.

--- a/docs/production.md
+++ b/docs/production.md
@@ -1,0 +1,188 @@
+# Production starter guide
+
+This guide describes the production contract implemented by the sample. It
+does not provision or deploy an identity provider, Redis, TLS endpoint, secret
+manager, load balancer, monitoring system, or backup system.
+
+## Security model
+
+The API is an OAuth-style resource server. A trusted external identity provider
+issues short-lived JWT access tokens. The application validates each token
+against one configured HTTPS JWKS endpoint and requires:
+
+- a signature from an explicitly allowed asymmetric algorithm;
+- the exact configured issuer and audience;
+- a valid expiration;
+- a non-empty `sub` claim; and
+- a non-empty configured tenant claim, `tenant_id` by default.
+
+The API HMACs `(tenant, subject)` into opaque Redis owner and Socket.IO room
+keys. Raw tenant and subject claims are not written into queue data. A refreshed
+token or another device for the same pair resolves to the same owner. Different
+users or tenants cannot read or acknowledge each other's tasks.
+
+This service does not decide whether the subject belongs to the tenant. The
+identity provider and its authorization policy must make and maintain that
+decision. Use access tokens targeted to this API, not ID tokens intended for a
+browser client.
+
+## Required configuration
+
+Production starts only when all required security settings are present:
+
+```dotenv
+NODE_ENV=production
+HOST=0.0.0.0
+PORT=3000
+PUBLIC_ORIGIN=https://notifier.example
+
+AUTH_MODE=oidc
+OIDC_ISSUER=https://identity.example/
+OIDC_AUDIENCE=https://notifier.example/api
+OIDC_JWKS_URL=https://identity.example/.well-known/jwks.json
+OIDC_ALGORITHMS=RS256
+OIDC_TENANT_CLAIM=tenant_id
+
+SESSION_SECRET=<at-least-32-random-bytes-from-a-secret-manager>
+REDIS_URL=rediss://notifier-user:<url-encoded-password>@redis.example:6380/0
+
+TASK_RETENTION_SECONDS=86400
+TASK_RATE_LIMIT=30
+TASK_RATE_WINDOW_SECONDS=60
+REPLAY_LIMIT=50
+WORKER_CONCURRENCY=4
+```
+
+`SESSION_SECRET` is the HMAC key for opaque owner and room identifiers even
+though production does not use the anonymous cookie. Rotating it makes
+previously indexed tasks inaccessible, so rotation requires an explicit
+migration or acceptance that retained notifications will expire unread.
+
+The allowed JWT algorithms are `RS256`, `PS256`, `ES256`, and `EdDSA`. Keep the
+allowlist as narrow as the provider permits. The issuer, audience, JWKS URL,
+tenant claim, and algorithm list are configuration, not values accepted from a
+request or token header.
+
+## Client contract
+
+Acquire the access token through the application's existing authorization-code
+flow. Send it in the HTTP authorization header and Socket.IO handshake data:
+
+```js
+const accessToken = await acquireAccessToken();
+
+const response = await fetch("/api/tasks", {
+  method: "POST",
+  headers: {
+    Authorization: `Bearer ${accessToken}`,
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({ message: "Prepare report" }),
+});
+
+const socket = io({
+  auth: { token: accessToken },
+  transports: ["websocket"],
+});
+```
+
+Do not place access tokens in URLs, logs, local storage, task messages, or
+queue payloads. Refresh a token through the identity SDK and reconnect the
+socket before expiration. The server disconnects a socket when the token used
+for its handshake expires.
+
+Available task routes:
+
+- `POST /api/tasks` creates a rate-limited job and returns `202`.
+- `GET /api/tasks?limit=50` lists recent tasks owned by the identity.
+- `GET /api/tasks/:id` reads one owned task.
+- `POST /api/tasks/:id/ack` records the first terminal acknowledgement.
+
+Cross-owner reads return `404`, avoiding a task-existence oracle.
+
+## Delivery semantics
+
+BullMQ job state and result are authoritative. Pub/Sub and Socket.IO are
+at-most-once wake-ups.
+
+When a socket connects, the API replays recent completed or failed tasks that
+do not have an acknowledgement. Acknowledgement uses an idempotent first-write
+receipt: repeated calls return the original `acknowledgedAt`.
+
+The receipt proves that an authorized client called the endpoint. It does not
+prove that a person saw, understood, or acted on a notification. Products that
+need those claims require additional workflow state and audit policy.
+
+`TASK_RETENTION_SECONDS` applies to BullMQ terminal jobs, identity indexes, and
+acknowledgements. It accepts 300 seconds through 30 days. Choose the value from
+product recovery requirements, data classification, storage capacity, and
+deletion policy.
+
+The fixed-window task creation limit is shared through Redis and scoped to the
+opaque owner key. A rejected request returns `429`, `Retry-After`, and rate
+limit metadata. It protects task creation, not bandwidth, authentication, or
+global denial-of-service boundaries; enforce those at the edge too.
+
+## Redis TLS and ACL boundary
+
+Production rejects `redis://` and URLs without both an ACL username and
+password. `rediss://` enables server certificate verification with Node's
+trusted roots.
+
+For a private certificate authority or mutual TLS, mount read-only files:
+
+```dotenv
+REDIS_CA_FILE=/run/secrets/redis-ca.pem
+REDIS_CERT_FILE=/run/secrets/redis-client.pem
+REDIS_KEY_FILE=/run/secrets/redis-client-key.pem
+```
+
+The certificate and key must be configured together. Keep their contents and
+the URL password in a secret manager; never commit them.
+
+Create a named Redis user limited to this application's key and channel
+prefixes. BullMQ uses `bull:<queue-name>:*`; this application also uses
+`<queue-name>:*` and `<event-channel>`. A starting ACL shape is:
+
+```text
+user notifier reset on >LONG_RANDOM_PASSWORD \
+  ~bull:notifier-demo:* ~notifier-demo:* \
+  &bull:notifier-demo:* &notifier-demo:events \
+  +@connection +@read +@write +@scripting +@pubsub +info -@dangerous
+```
+
+Command categories can change as Redis and BullMQ evolve. Validate the exact
+rule with Redis `ACL DRYRUN`, the repository integration suite, and the chosen
+managed service; do not grant `+@all` merely to bypass a failed test. Keep
+Redis on a private network and configure backups, restore exercises,
+availability, memory policy, monitoring, and alerting separately.
+
+## Health and scaling
+
+- `/health/live` proves the process can answer HTTP.
+- `/health/ready` requires a Redis `PING`; remove an instance from routing when
+  it returns `503`.
+- API replicas subscribe to the shared completion channel and use
+  WebSocket-only transport, avoiding long-polling stickiness.
+- Workers may scale independently, but downstream operations must be
+  idempotent and concurrency must be capped to downstream capacity.
+
+Set reverse-proxy timeouts for WebSockets, preserve the exact public Origin,
+terminate current TLS, and bound request size at both the edge and application.
+
+## Pre-deployment gate
+
+Before deploying:
+
+1. choose and test the identity provider's tenant-membership and revocation
+   behavior;
+2. configure HTTPS, secret injection, the Redis ACL/TLS connection, backups,
+   restore tests, capacity, and alerting;
+3. choose retention, rate limits, acknowledgement meaning, data
+   classification, and deletion/audit policy;
+4. replace the simulated worker with an idempotent operation;
+5. run unit, Redis integration, container, load, failure, and rollback tests;
+6. review the applicable Redis 8 license; and
+7. identify a rollback target before changing production.
+
+No deployment configuration or paid resource is created by this repository.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -8,7 +8,8 @@ By the end of this lab, you should be able to explain:
 2. which data must be durable and which event may be ephemeral;
 3. why a socket ID is not authentication;
 4. how a disconnected browser recovers missed state; and
-5. what changes when API and worker processes scale independently.
+5. what an explicit delivery acknowledgement proves; and
+6. what changes when API and worker processes scale independently.
 
 The exercises run locally. They do not create cloud resources or use a paid
 service.
@@ -55,6 +56,7 @@ Observe:
 3. The worker saves the result before publishing a live update hint.
 4. The API instance with your socket emits `task:update`.
 5. The browser reads the task endpoint and renders the saved result.
+6. **Mark seen** stores an idempotent acknowledgement outside the socket.
 
 The browser never receives or submits its Socket.IO connection ID. Open
 Developer Tools and inspect the `POST /api/tasks` response: it contains a task
@@ -94,14 +96,20 @@ TASK_DELAY_MS=8000 docker compose up
 Queue a task, then close the tab before it finishes. Wait eight seconds and
 reopen <http://localhost:3000>.
 
-The original demo could not notify a new socket ID. This page remembers recent
-task IDs in local storage, keeps the anonymous session in a signed cookie, and
-reads each task from the API after load. The saved result appears even though
-the live socket event was missed.
+The original demo could not notify a new socket ID. This page keeps the
+anonymous identity in a signed cookie, indexes recent tasks by a server-derived
+owner key, and reads them from the API after load. Local storage remains a
+client-side fallback. The saved result appears even though the live socket
+event was missed.
 
-This proves result recovery for the same anonymous browser session. It does
-not claim human acknowledgement or cross-device delivery. Those require
-product-specific authenticated identity and receipt semantics.
+Do not choose **Mark seen**, close the tab, and open it again. The API replays
+the unacknowledged terminal task to the replacement socket. Now choose
+**Mark seen**. Repeating the acknowledgement returns the original timestamp,
+and later reconnects no longer replay that task.
+
+This local exercise proves recovery for one anonymous browser identity.
+Production mode applies the same mechanism to a validated tenant and subject
+across devices.
 
 ## 5. Exercise cross-instance fan-out
 
@@ -120,6 +128,12 @@ The test:
 5. receives the worker's completion through API B;
 6. proves another session cannot read the task; and
 7. disconnects the socket and recovers a later result through the task API.
+
+A second integration case runs the production identity contract without a
+vendor dependency. It proves token refresh and cross-device replay for the
+same tenant and subject, isolation across users and tenants, idempotent
+acknowledgement, suppression after acknowledgement, and Redis-backed `429`
+rate limiting.
 
 That is a bounded functional proof of the sample's scale-out design. It is not
 a load, chaos, or production failover test.
@@ -148,7 +162,6 @@ The local demo provides:
 
 - a random HMAC-signed session cookie;
 - HttpOnly and SameSite=Strict cookie attributes;
-- a Secure cookie when `NODE_ENV=production`;
 - exact-Origin checks for task creation;
 - server-derived, non-public Socket.IO rooms;
 - task ownership checks that return 404 across sessions;
@@ -157,21 +170,32 @@ The local demo provides:
 - an unprivileged, read-only application container; and
 - no host-published data-store port.
 
-It does not provide:
+Production mode adds:
 
-- user login, tenant authorization, or session revocation;
-- TLS termination or reverse-proxy configuration;
-- a production secret manager;
-- distributed rate limiting;
-- Redis ACLs, TLS, backup policy, or high availability;
-- audit/event retention policy;
-- notification acknowledgement; or
-- production deployment configuration.
+- JWT signature, algorithm, issuer, audience, expiration, subject, and tenant
+  validation against a fixed JWKS URL;
+- stable cross-device owner and room derivation without storing raw claims;
+- token-expiry disconnect for sockets;
+- Redis-backed per-identity task rate limiting;
+- recent-task indexing and explicit acknowledgement;
+- configurable bounded retention; and
+- startup enforcement for HTTPS origin and ACL-authenticated TLS Redis.
 
-Those are explicit owner and product decisions, not gaps to hide behind a
-tutorial default.
+The application still delegates login, consent, MFA, token issuance and
+revocation, tenant membership, and authorization policy to the chosen identity
+provider. It does not terminate TLS, create secrets, deploy Redis, configure
+backups, or choose compliance retention.
 
-## 8. Clean up
+## 8. Follow the production contract
+
+Read [the production guide](production.md). It shows the required environment,
+client authorization headers and Socket.IO handshake, Redis ACL/TLS boundary,
+acknowledgement semantics, and pre-deployment checklist.
+
+Do not copy the local Compose secret or anonymous identity into production.
+Production startup rejects that configuration.
+
+## 9. Clean up
 
 Stop containers while preserving recent Redis state:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "express": "5.2.1",
         "helmet": "8.3.0",
         "ioredis": "5.11.1",
+        "jose": "6.2.4",
         "socket.io": "4.8.3"
       },
       "devDependencies": {
@@ -799,6 +800,15 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/jose": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
+      "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/luxon": {
       "version": "3.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sample-notifier-service",
   "version": "2.0.0",
-  "description": "A secure, reconnect-safe tutorial for notifying browsers when background jobs finish.",
+  "description": "A durable browser notification tutorial and provider-neutral production starter.",
   "private": true,
   "type": "module",
   "engines": {
@@ -21,6 +21,7 @@
     "express": "5.2.1",
     "helmet": "8.3.0",
     "ioredis": "5.11.1",
+    "jose": "6.2.4",
     "socket.io": "4.8.3"
   },
   "devDependencies": {

--- a/public/app.js
+++ b/public/app.js
@@ -83,6 +83,14 @@ function renderTask(task) {
     (task.status === "running"
       ? "The worker has claimed this job."
       : "Waiting for a worker.");
+
+  const acknowledgement = element.querySelector(".task__ack");
+  const acknowledgedAt = task.delivery?.acknowledgedAt;
+  const terminal = task.status === "completed" || task.status === "failed";
+  acknowledgement.hidden = !terminal;
+  acknowledgement.disabled = Boolean(acknowledgedAt);
+  acknowledgement.dataset.taskId = task.taskId;
+  acknowledgement.textContent = acknowledgedAt ? "Seen" : "Mark seen";
 }
 
 async function fetchTask(taskId) {
@@ -100,8 +108,25 @@ async function fetchTask(taskId) {
   renderTask(await response.json());
 }
 
-async function reconcileRememberedTasks() {
-  await Promise.allSettled(rememberedTaskIds().map(fetchTask));
+async function fetchRecentTasks() {
+  const response = await fetch("/api/tasks?limit=12", {
+    headers: { Accept: "application/json" },
+  });
+  if (!response.ok) {
+    throw new Error("Could not load recent task state.");
+  }
+  const body = await response.json();
+  for (const task of body.tasks ?? []) {
+    rememberTask(task.taskId);
+    renderTask(task);
+  }
+}
+
+async function reconcileTasks() {
+  await Promise.allSettled([
+    fetchRecentTasks(),
+    ...rememberedTaskIds().map(fetchTask),
+  ]);
 }
 
 form.addEventListener("submit", async (event) => {
@@ -139,6 +164,31 @@ form.addEventListener("submit", async (event) => {
   }
 });
 
+taskList.addEventListener("click", async (event) => {
+  const button = event.target.closest(".task__ack");
+  if (!button || button.disabled) {
+    return;
+  }
+  button.disabled = true;
+  try {
+    const response = await fetch(
+      `/api/tasks/${encodeURIComponent(button.dataset.taskId)}/ack`,
+      {
+        method: "POST",
+        headers: { Accept: "application/json" },
+      },
+    );
+    const body = await response.json();
+    if (!response.ok) {
+      throw new Error(body.error ?? "Could not acknowledge this task.");
+    }
+    await fetchTask(button.dataset.taskId);
+  } catch (error) {
+    formError.textContent = error.message;
+    button.disabled = false;
+  }
+});
+
 const socket = io({
   transports: ["websocket"],
 });
@@ -146,7 +196,7 @@ const socket = io({
 socket.on("connect", () => {
   connectionDot.dataset.connected = "true";
   connectionStatus.textContent = "Live notifications connected";
-  void reconcileRememberedTasks();
+  void reconcileTasks();
 });
 
 socket.on("disconnect", () => {
@@ -165,4 +215,4 @@ socket.on("task:update", (event) => {
   }
 });
 
-void reconcileRememberedTasks();
+void reconcileTasks();

--- a/public/index.html
+++ b/public/index.html
@@ -56,7 +56,8 @@
           <h2 id="results-heading">Observe state reconciliation</h2>
           <p>
             Socket events trigger an immediate refresh. Reloading the page
-            asks the API for the same task state, so a missed event is harmless.
+            asks the API for recent task state, and “Mark seen” records an
+            explicit delivery acknowledgement.
           </p>
         </div>
         <ol id="task-list" class="task-list" aria-live="polite">
@@ -70,8 +71,9 @@
         <p class="step">Core lesson</p>
         <p>
           A socket ID identifies one transport connection; it is neither an
-          identity nor a delivery receipt. This demo routes through a
-          server-derived session room and keeps the task result in the queue.
+          identity nor a delivery receipt. Local mode uses a server-derived
+          session identity; production mode requires validated tenant and user
+          claims. Both keep results and acknowledgements outside the socket.
         </p>
         <a
           href="https://github.com/pulkitsinghal/sample-notifier-service/blob/master/docs/tutorial.md"
@@ -87,6 +89,7 @@
         </div>
         <p class="task__message"></p>
         <p class="task__result"></p>
+        <button class="task__ack" type="button" hidden>Mark seen</button>
         <code class="task__id"></code>
       </li>
     </template>

--- a/public/styles.css
+++ b/public/styles.css
@@ -234,6 +234,25 @@ button:disabled {
   font-size: 0.9rem;
 }
 
+.task__ack {
+  min-height: 2.2rem;
+  margin: 0 0.7rem 0.65rem 0;
+  padding: 0 0.8rem;
+  border: 1px solid var(--line);
+  background: var(--paper);
+  color: var(--ink);
+  font-size: 0.8rem;
+}
+
+.task__ack:hover {
+  background: #e8e4d9;
+}
+
+.task__ack:disabled {
+  cursor: default;
+  opacity: 0.7;
+}
+
 .task__id {
   color: #66736e;
   font-size: 0.72rem;

--- a/src/api.js
+++ b/src/api.js
@@ -9,14 +9,15 @@ import helmet from "helmet";
 import IORedis from "ioredis";
 import { Server as SocketServer } from "socket.io";
 
-import { DEFAULT_JOB_OPTIONS, redisConnectionOptions } from "./queue.js";
+import { createIdentityService } from "./identity.js";
+import { consumeRateLimit } from "./rate-limit.js";
 import {
-  createSession,
-  deriveNotificationRoom,
-  readSessionId,
-  serializeSessionCookie,
-} from "./session.js";
+  jobOptions,
+  redisConnectionOptions,
+} from "./queue.js";
+import { TaskStore } from "./task-store.js";
 import {
+  isTerminalTask,
   parseTaskMessage,
   presentJob,
   publicTaskEvent,
@@ -26,6 +27,9 @@ const publicDirectory = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "../public",
 );
+
+const TASK_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function expectedOrigin(request, configuredOrigin) {
   if (configuredOrigin) {
@@ -43,30 +47,6 @@ function expectedOrigin(request, configuredOrigin) {
 function originIsAllowed(request, configuredOrigin) {
   const origin = request.headers.origin;
   return Boolean(origin && origin === expectedOrigin(request, configuredOrigin));
-}
-
-function sessionMiddleware({ sessionSecret, secure }) {
-  return (request, response, next) => {
-    let sessionId = readSessionId(
-      request.headers.cookie,
-      sessionSecret,
-    );
-
-    if (!sessionId) {
-      const session = createSession(sessionSecret);
-      sessionId = session.sessionId;
-      response.setHeader(
-        "Set-Cookie",
-        serializeSessionCookie(session.token, { secure }),
-      );
-    }
-
-    request.notificationRoom = deriveNotificationRoom(
-      sessionId,
-      sessionSecret,
-    );
-    next();
-  };
 }
 
 function requireSameOrigin(configuredOrigin) {
@@ -88,8 +68,48 @@ function closeHttpServer(server) {
   });
 }
 
+function parseListLimit(value, fallback) {
+  if (value === undefined) {
+    return fallback;
+  }
+  if (!/^\d+$/.test(value)) {
+    const error = new Error("limit must be an integer between 1 and 100");
+    error.statusCode = 400;
+    throw error;
+  }
+  const limit = Number(value);
+  if (limit < 1 || limit > 100) {
+    const error = new Error("limit must be an integer between 1 and 100");
+    error.statusCode = 400;
+    throw error;
+  }
+  return limit;
+}
+
+function notFound(response) {
+  response.status(404).json({ error: "Task not found." });
+}
+
+function disconnectAtTokenExpiry(socket, expiresAt) {
+  if (!expiresAt) {
+    return;
+  }
+  let timer;
+  const schedule = () => {
+    const remaining = expiresAt * 1000 - Date.now();
+    if (remaining <= 0) {
+      socket.disconnect(true);
+      return;
+    }
+    timer = setTimeout(schedule, Math.min(remaining, 2_147_000_000));
+  };
+  schedule();
+  socket.once("disconnect", () => clearTimeout(timer));
+}
+
 export async function createNotifierApi({
   redisUrl,
+  redisTls = {},
   queueName,
   eventChannel,
   sessionSecret,
@@ -97,17 +117,31 @@ export async function createNotifierApi({
   host = "127.0.0.1",
   port = 3000,
   isProduction = false,
+  authMode = "anonymous",
+  oidcIssuer = null,
+  oidcAudience = null,
+  oidcJwksUrl = null,
+  oidcAlgorithms = ["RS256"],
+  oidcTenantClaim = "tenant_id",
+  tokenVerifier = null,
+  taskRetentionSeconds = 24 * 60 * 60,
+  taskRateLimit = 30,
+  taskRateWindowSeconds = 60,
+  replayLimit = 50,
   logger = console,
 }) {
+  const connection = redisConnectionOptions(redisUrl, redisTls);
   const queue = new Queue(queueName, {
-    connection: redisConnectionOptions(redisUrl),
-    defaultJobOptions: DEFAULT_JOB_OPTIONS,
+    connection,
+    defaultJobOptions: jobOptions(taskRetentionSeconds),
   });
-  const subscriber = new IORedis(redisUrl, {
+  const subscriber = new IORedis({
+    ...connection,
     lazyConnect: true,
     maxRetriesPerRequest: null,
   });
-  const healthRedis = new IORedis(redisUrl, {
+  const controlRedis = new IORedis({
+    ...connection,
     lazyConnect: true,
     maxRetriesPerRequest: 1,
   });
@@ -115,52 +149,111 @@ export async function createNotifierApi({
   subscriber.on("error", (error) => {
     logger.error("Notification subscriber error", error.message);
   });
-  healthRedis.on("error", () => {
-    // Readiness reports the failure without logging connection details.
+  controlRedis.on("error", () => {
+    // Readiness reports failures without logging connection details.
   });
 
   await Promise.all([
     queue.waitUntilReady(),
     subscriber.connect(),
-    healthRedis.connect(),
+    controlRedis.connect(),
   ]);
+
+  const taskStore = new TaskStore(controlRedis, {
+    namespace: queueName,
+    retentionSeconds: taskRetentionSeconds,
+  });
+  const identities = createIdentityService({
+    authMode,
+    sessionSecret,
+    taskRetentionSeconds,
+    secureCookies: isProduction,
+    oidcIssuer,
+    oidcAudience,
+    oidcJwksUrl,
+    oidcAlgorithms,
+    oidcTenantClaim,
+    tokenVerifier,
+  });
 
   const app = express();
   const httpServer = createServer(app);
   const io = new SocketServer(httpServer, {
     allowRequest: (request, callback) => {
       const allowed = originIsAllowed(request, publicOrigin);
-      callback(
-        allowed ? null : "origin is not allowed",
-        allowed,
-      );
+      callback(allowed ? null : "origin is not allowed", allowed);
     },
-    serveClient: true,
+    serveClient: !isProduction,
     transports: ["websocket"],
   });
 
-  io.use((socket, next) => {
-    const sessionId = readSessionId(
-      socket.request.headers.cookie,
-      sessionSecret,
-    );
-    if (!sessionId) {
-      next(new Error("session is required"));
-      return;
+  async function ownedJob(taskId, ownerKey) {
+    if (!TASK_ID_PATTERN.test(taskId)) {
+      return null;
     }
+    const job = await queue.getJob(taskId);
+    return job?.data.ownerKey === ownerKey ? job : null;
+  }
 
-    socket.data.notificationRoom = deriveNotificationRoom(
-      sessionId,
-      sessionSecret,
+  async function taskRepresentation(job) {
+    return presentJob(
+      job,
+      await taskStore.acknowledgement(String(job.id)),
     );
-    next();
+  }
+
+  async function recentTasks(ownerKey, limit) {
+    const taskIds = await taskStore.listTaskIds(ownerKey, limit);
+    const jobs = await Promise.all(
+      taskIds.map((taskId) => queue.getJob(taskId)),
+    );
+    const ownedJobs = jobs.filter(
+      (job) => job?.data.ownerKey === ownerKey,
+    );
+    return Promise.all(ownedJobs.map(taskRepresentation));
+  }
+
+  io.use(async (socket, next) => {
+    try {
+      socket.data.identity = await identities.authenticateSocket(socket);
+      next();
+    } catch {
+      next(new Error("authentication is required"));
+    }
   });
 
   io.on("connection", (socket) => {
-    socket.join(socket.data.notificationRoom);
+    const {
+      notificationRoom,
+      ownerKey,
+      expiresAt,
+    } = socket.data.identity;
+    disconnectAtTokenExpiry(socket, expiresAt);
+    socket.join(notificationRoom);
     socket.emit("notifier:ready", {
       connectedAt: new Date().toISOString(),
     });
+
+    void recentTasks(ownerKey, replayLimit)
+      .then((tasks) => {
+        for (const task of tasks) {
+          if (
+            isTerminalTask(task.status) &&
+            !task.delivery.acknowledgedAt
+          ) {
+            socket.emit("task:update", {
+              taskId: task.taskId,
+              status: task.status,
+              result: task.result,
+              error: task.error,
+              replayed: true,
+            });
+          }
+        }
+      })
+      .catch((error) => {
+        logger.warn("Could not replay pending task updates", error.message);
+      });
   });
 
   subscriber.on("message", (channel, payload) => {
@@ -206,7 +299,7 @@ export async function createNotifierApi({
 
   app.get("/health/ready", async (_request, response) => {
     try {
-      await healthRedis.ping();
+      await controlRedis.ping();
       response.json({ status: "ready" });
     } catch {
       response.status(503).json({ status: "not-ready" });
@@ -214,7 +307,17 @@ export async function createNotifierApi({
   });
 
   app.use(express.json({ limit: "8kb", strict: true }));
-  app.use(sessionMiddleware({ sessionSecret, secure: isProduction }));
+  app.use(async (request, response, next) => {
+    try {
+      request.identity = await identities.authenticateRequest(
+        request,
+        response,
+      );
+      next();
+    } catch (error) {
+      next(error);
+    }
+  });
 
   app.get("/api/session", (_request, response) => {
     response.setHeader("Cache-Control", "no-store");
@@ -226,17 +329,49 @@ export async function createNotifierApi({
     requireSameOrigin(publicOrigin),
     async (request, response, next) => {
       try {
+        const rate = await consumeRateLimit(controlRedis, {
+          namespace: queueName,
+          ownerKey: request.identity.ownerKey,
+          limit: taskRateLimit,
+          windowSeconds: taskRateWindowSeconds,
+        });
+        response.setHeader("X-RateLimit-Limit", String(rate.limit));
+        response.setHeader(
+          "X-RateLimit-Remaining",
+          String(rate.remaining),
+        );
+        response.setHeader("X-RateLimit-Reset", String(rate.resetAt));
+        if (!rate.allowed) {
+          response.setHeader(
+            "Retry-After",
+            String(Math.max(1, rate.resetAt - Math.floor(Date.now() / 1000))),
+          );
+          response.status(429).json({
+            error: "Too many task requests. Try again after the rate limit resets.",
+          });
+          return;
+        }
+
         const message = parseTaskMessage(request.body);
         const taskId = randomUUID();
-        await queue.add(
-          "demo-task",
-          {
-            message,
-            notificationRoom: request.notificationRoom,
-            requestedAt: new Date().toISOString(),
-          },
-          { jobId: taskId },
-        );
+        await taskStore.remember(request.identity.ownerKey, taskId);
+        try {
+          await queue.add(
+            "demo-task",
+            {
+              message,
+              ownerKey: request.identity.ownerKey,
+              notificationRoom: request.identity.notificationRoom,
+              requestedAt: new Date().toISOString(),
+            },
+            { jobId: taskId },
+          );
+        } catch (error) {
+          await taskStore
+            .forget(request.identity.ownerKey, taskId)
+            .catch(() => {});
+          throw error;
+        }
 
         response
           .status(202)
@@ -248,39 +383,77 @@ export async function createNotifierApi({
     },
   );
 
-  app.get("/api/tasks/:taskId", async (request, response, next) => {
+  app.get("/api/tasks", async (request, response, next) => {
     try {
-      if (
-        !/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
-          request.params.taskId,
-        )
-      ) {
-        response.status(404).json({ error: "Task not found." });
-        return;
-      }
-
-      const job = await queue.getJob(request.params.taskId);
-      if (
-        !job ||
-        job.data.notificationRoom !== request.notificationRoom
-      ) {
-        response.status(404).json({ error: "Task not found." });
-        return;
-      }
-
+      const limit = parseListLimit(request.query.limit, replayLimit);
       response.setHeader("Cache-Control", "no-store");
-      response.json(await presentJob(job));
+      response.json({
+        tasks: await recentTasks(request.identity.ownerKey, limit),
+      });
     } catch (error) {
       next(error);
     }
   });
 
-  app.use(
-    express.static(publicDirectory, {
-      etag: true,
-      maxAge: 0,
-    }),
+  app.get("/api/tasks/:taskId", async (request, response, next) => {
+    try {
+      const job = await ownedJob(
+        request.params.taskId,
+        request.identity.ownerKey,
+      );
+      if (!job) {
+        notFound(response);
+        return;
+      }
+
+      response.setHeader("Cache-Control", "no-store");
+      response.json(await taskRepresentation(job));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.post(
+    "/api/tasks/:taskId/ack",
+    requireSameOrigin(publicOrigin),
+    async (request, response, next) => {
+      try {
+        const job = await ownedJob(
+          request.params.taskId,
+          request.identity.ownerKey,
+        );
+        if (!job) {
+          notFound(response);
+          return;
+        }
+
+        const task = await taskRepresentation(job);
+        if (!isTerminalTask(task.status)) {
+          response.status(409).json({
+            error: "Only completed or failed tasks can be acknowledged.",
+          });
+          return;
+        }
+
+        response.setHeader("Cache-Control", "no-store");
+        response.json({
+          taskId: String(job.id),
+          delivery: await taskStore.acknowledge(String(job.id)),
+        });
+      } catch (error) {
+        next(error);
+      }
+    },
   );
+
+  if (!isProduction) {
+    app.use(
+      express.static(publicDirectory, {
+        etag: true,
+        maxAge: 0,
+      }),
+    );
+  }
 
   app.use("/api", (_request, response) => {
     response.status(404).json({ error: "API route not found." });
@@ -296,6 +469,9 @@ export async function createNotifierApi({
           ? 413
           : 500;
 
+    if (error.authenticate) {
+      response.setHeader("WWW-Authenticate", error.authenticate);
+    }
     if (statusCode >= 500) {
       logger.error("Request failed", error.message);
     }
@@ -340,7 +516,7 @@ export async function createNotifierApi({
       await Promise.allSettled([
         queue.close(),
         subscriber.quit(),
-        healthRedis.quit(),
+        controlRedis.quit(),
       ]);
     },
   };

--- a/src/config.js
+++ b/src/config.js
@@ -5,7 +5,21 @@ const DEFAULTS = Object.freeze({
   eventChannel: "notifier-demo:events",
   taskDelayMs: 1200,
   workerConcurrency: 4,
+  taskRetentionSeconds: 24 * 60 * 60,
+  taskRateLimit: 30,
+  taskRateWindowSeconds: 60,
+  replayLimit: 50,
+  authMode: "anonymous",
+  oidcAlgorithms: "RS256",
+  oidcTenantClaim: "tenant_id",
 });
+
+const ALLOWED_OIDC_ALGORITHMS = new Set([
+  "RS256",
+  "PS256",
+  "ES256",
+  "EdDSA",
+]);
 
 function parseInteger(name, value, { min, max }) {
   const parsed = Number(value);
@@ -34,7 +48,7 @@ function parseRedisUrl(value) {
     throw new Error("REDIS_URL database path must be a non-negative integer");
   }
 
-  return url.toString();
+  return url;
 }
 
 function parsePublicOrigin(value) {
@@ -59,6 +73,26 @@ function parsePublicOrigin(value) {
   return url.origin;
 }
 
+function parseHttpsUrl(name, value) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`${name} must be a valid https:// URL`);
+  }
+
+  if (
+    url.protocol !== "https:" ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash
+  ) {
+    throw new Error(`${name} must use https:// without credentials, query, or fragment`);
+  }
+  return value;
+}
+
 function parseName(name, value, { allowColon = false } = {}) {
   const pattern = allowColon
     ? /^[A-Za-z0-9][A-Za-z0-9:_-]{0,79}$/
@@ -69,29 +103,129 @@ function parseName(name, value, { allowColon = false } = {}) {
   return value;
 }
 
+function parseRequiredText(name, value, { max = 256 } = {}) {
+  if (typeof value !== "string" || !value.trim() || value.length > max) {
+    throw new Error(`${name} must contain between 1 and ${max} characters`);
+  }
+  return value.trim();
+}
+
+function parseAuthMode(value) {
+  if (!["anonymous", "oidc"].includes(value)) {
+    throw new Error("AUTH_MODE must be anonymous or oidc");
+  }
+  return value;
+}
+
+function parseOidcAlgorithms(value) {
+  const algorithms = value
+    .split(",")
+    .map((algorithm) => algorithm.trim())
+    .filter(Boolean);
+  if (
+    algorithms.length === 0 ||
+    new Set(algorithms).size !== algorithms.length ||
+    algorithms.some((algorithm) => !ALLOWED_OIDC_ALGORITHMS.has(algorithm))
+  ) {
+    throw new Error(
+      "OIDC_ALGORITHMS must be a unique comma-separated subset of RS256, PS256, ES256, or EdDSA",
+    );
+  }
+  return Object.freeze(algorithms);
+}
+
+function parseOptionalPath(name, value) {
+  if (value === undefined || value === "") {
+    return null;
+  }
+  if (
+    typeof value !== "string" ||
+    !value.startsWith("/") ||
+    value.includes("\0")
+  ) {
+    throw new Error(`${name} must be an absolute file path`);
+  }
+  return value;
+}
+
 export function loadConfig(env = process.env) {
   const nodeEnv = env.NODE_ENV ?? "development";
+  const isProduction = nodeEnv === "production";
   const sessionSecret = env.SESSION_SECRET;
+  const authMode = parseAuthMode(env.AUTH_MODE ?? DEFAULTS.authMode);
   const publicOrigin = parsePublicOrigin(
     env.PUBLIC_ORIGIN ?? `http://localhost:${env.PORT ?? DEFAULTS.port}`,
   );
+  const redisUrl = parseRedisUrl(env.REDIS_URL ?? DEFAULTS.redisUrl);
+  const redisTls = {
+    caFile: parseOptionalPath("REDIS_CA_FILE", env.REDIS_CA_FILE),
+    certFile: parseOptionalPath("REDIS_CERT_FILE", env.REDIS_CERT_FILE),
+    keyFile: parseOptionalPath("REDIS_KEY_FILE", env.REDIS_KEY_FILE),
+  };
 
   if (!sessionSecret || Buffer.byteLength(sessionSecret) < 32) {
     throw new Error("SESSION_SECRET must contain at least 32 bytes");
   }
-  if (nodeEnv === "production" && !publicOrigin.startsWith("https://")) {
+  if (isProduction && !publicOrigin.startsWith("https://")) {
     throw new Error("PUBLIC_ORIGIN must use https:// in production");
+  }
+  if (isProduction && authMode !== "oidc") {
+    throw new Error("AUTH_MODE must be oidc in production");
+  }
+  if (
+    isProduction &&
+    (
+      redisUrl.protocol !== "rediss:" ||
+      !redisUrl.username ||
+      !redisUrl.password
+    )
+  ) {
+    throw new Error(
+      "production REDIS_URL must use rediss:// with an ACL username and password",
+    );
+  }
+  if (Boolean(redisTls.certFile) !== Boolean(redisTls.keyFile)) {
+    throw new Error("REDIS_CERT_FILE and REDIS_KEY_FILE must be configured together");
+  }
+
+  let oidcIssuer = null;
+  let oidcAudience = null;
+  let oidcJwksUrl = null;
+  let oidcAlgorithms = Object.freeze([]);
+  let oidcTenantClaim = null;
+  if (authMode === "oidc") {
+    oidcIssuer = parseHttpsUrl(
+      "OIDC_ISSUER",
+      parseRequiredText("OIDC_ISSUER", env.OIDC_ISSUER),
+    );
+    oidcAudience = parseRequiredText("OIDC_AUDIENCE", env.OIDC_AUDIENCE);
+    oidcJwksUrl = parseHttpsUrl(
+      "OIDC_JWKS_URL",
+      parseRequiredText("OIDC_JWKS_URL", env.OIDC_JWKS_URL),
+    );
+    oidcAlgorithms = parseOidcAlgorithms(
+      env.OIDC_ALGORITHMS ?? DEFAULTS.oidcAlgorithms,
+    );
+    oidcTenantClaim = parseRequiredText(
+      "OIDC_TENANT_CLAIM",
+      env.OIDC_TENANT_CLAIM ?? DEFAULTS.oidcTenantClaim,
+      { max: 64 },
+    );
+    if (!/^[A-Za-z_][A-Za-z0-9_.-]{0,63}$/.test(oidcTenantClaim)) {
+      throw new Error("OIDC_TENANT_CLAIM must be a simple claim name");
+    }
   }
 
   return Object.freeze({
     nodeEnv,
-    isProduction: nodeEnv === "production",
+    isProduction,
     host: env.HOST ?? "127.0.0.1",
     port: parseInteger("PORT", env.PORT ?? DEFAULTS.port, {
       min: 1,
       max: 65535,
     }),
-    redisUrl: parseRedisUrl(env.REDIS_URL ?? DEFAULTS.redisUrl),
+    redisUrl: redisUrl.toString(),
+    redisTls: Object.freeze(redisTls),
     publicOrigin,
     queueName: parseName("QUEUE_NAME", env.QUEUE_NAME ?? DEFAULTS.queueName),
     eventChannel: parseName(
@@ -110,5 +244,31 @@ export function loadConfig(env = process.env) {
       env.WORKER_CONCURRENCY ?? DEFAULTS.workerConcurrency,
       { min: 1, max: 64 },
     ),
+    taskRetentionSeconds: parseInteger(
+      "TASK_RETENTION_SECONDS",
+      env.TASK_RETENTION_SECONDS ?? DEFAULTS.taskRetentionSeconds,
+      { min: 300, max: 30 * 24 * 60 * 60 },
+    ),
+    taskRateLimit: parseInteger(
+      "TASK_RATE_LIMIT",
+      env.TASK_RATE_LIMIT ?? DEFAULTS.taskRateLimit,
+      { min: 1, max: 1000 },
+    ),
+    taskRateWindowSeconds: parseInteger(
+      "TASK_RATE_WINDOW_SECONDS",
+      env.TASK_RATE_WINDOW_SECONDS ?? DEFAULTS.taskRateWindowSeconds,
+      { min: 1, max: 60 * 60 },
+    ),
+    replayLimit: parseInteger(
+      "REPLAY_LIMIT",
+      env.REPLAY_LIMIT ?? DEFAULTS.replayLimit,
+      { min: 1, max: 100 },
+    ),
+    authMode,
+    oidcIssuer,
+    oidcAudience,
+    oidcJwksUrl,
+    oidcAlgorithms,
+    oidcTenantClaim,
   });
 }

--- a/src/identity.js
+++ b/src/identity.js
@@ -1,0 +1,159 @@
+import {
+  createRemoteJWKSet,
+  jwtVerify,
+} from "jose";
+
+import {
+  createSession,
+  deriveIdentityOwner,
+  deriveIdentityRoom,
+  readSessionId,
+  serializeSessionCookie,
+} from "./session.js";
+
+function unauthorized(message = "Authentication is required.") {
+  const error = new Error(message);
+  error.statusCode = 401;
+  error.authenticate = "Bearer";
+  return error;
+}
+
+function bearerToken(header) {
+  if (typeof header !== "string") {
+    return null;
+  }
+  const match = /^Bearer ([A-Za-z0-9\-._~+/]+=*)$/.exec(header);
+  if (!match || match[1].length > 8192) {
+    return null;
+  }
+  return match[1];
+}
+
+function claimText(payload, name) {
+  const value = payload[name];
+  if (
+    typeof value !== "string" ||
+    !value ||
+    value.length > 256
+  ) {
+    throw unauthorized("The access token is missing required identity claims.");
+  }
+  return value;
+}
+
+function claimExpiration(payload) {
+  if (!Number.isInteger(payload.exp) || payload.exp <= 0) {
+    throw unauthorized("The access token is missing a valid expiration.");
+  }
+  return payload.exp;
+}
+
+function identityFor(
+  tenant,
+  subject,
+  sessionSecret,
+  expiresAt = null,
+) {
+  return Object.freeze({
+    ownerKey: deriveIdentityOwner(tenant, subject, sessionSecret),
+    notificationRoom: deriveIdentityRoom(tenant, subject, sessionSecret),
+    expiresAt,
+  });
+}
+
+export function createOidcTokenVerifier({
+  issuer,
+  audience,
+  jwksUrl = null,
+  algorithms = ["RS256"],
+  tenantClaim = "tenant_id",
+  keySet = null,
+}) {
+  const jwks = keySet ?? createRemoteJWKSet(new URL(jwksUrl));
+  return (token) =>
+    jwtVerify(token, jwks, {
+      issuer,
+      audience,
+      algorithms,
+      requiredClaims: ["sub", tenantClaim, "exp"],
+    });
+}
+
+export function createIdentityService({
+  authMode = "anonymous",
+  sessionSecret,
+  taskRetentionSeconds = 24 * 60 * 60,
+  secureCookies = false,
+  oidcIssuer = null,
+  oidcAudience = null,
+  oidcJwksUrl = null,
+  oidcAlgorithms = ["RS256"],
+  oidcTenantClaim = "tenant_id",
+  tokenVerifier = null,
+}) {
+  const verifyToken =
+    authMode === "oidc"
+      ? tokenVerifier ??
+        createOidcTokenVerifier({
+          issuer: oidcIssuer,
+          audience: oidcAudience,
+          jwksUrl: oidcJwksUrl,
+          algorithms: oidcAlgorithms,
+          tenantClaim: oidcTenantClaim,
+        })
+      : null;
+
+  async function oidcIdentity(token) {
+    if (!token) {
+      throw unauthorized();
+    }
+    try {
+      const { payload } = await verifyToken(token);
+      return identityFor(
+        claimText(payload, oidcTenantClaim),
+        claimText(payload, "sub"),
+        sessionSecret,
+        claimExpiration(payload),
+      );
+    } catch (error) {
+      if (error?.statusCode === 401) {
+        throw error;
+      }
+      throw unauthorized("The access token is invalid or expired.");
+    }
+  }
+
+  function anonymousIdentity(cookieHeader, response = null) {
+    let sessionId = readSessionId(cookieHeader, sessionSecret);
+    if (!sessionId) {
+      if (!response) {
+        throw unauthorized("A tutorial session is required.");
+      }
+      const session = createSession(sessionSecret);
+      sessionId = session.sessionId;
+      response.setHeader(
+        "Set-Cookie",
+        serializeSessionCookie(session.token, {
+          secure: secureCookies,
+          maxAgeSeconds: taskRetentionSeconds,
+        }),
+      );
+    }
+    return identityFor("local", sessionId, sessionSecret);
+  }
+
+  return Object.freeze({
+    async authenticateRequest(request, response) {
+      if (authMode === "oidc") {
+        return oidcIdentity(bearerToken(request.headers.authorization));
+      }
+      return anonymousIdentity(request.headers.cookie, response);
+    },
+    async authenticateSocket(socket) {
+      if (authMode === "oidc") {
+        return oidcIdentity(socket.handshake.auth?.token);
+      }
+      return anonymousIdentity(socket.request.headers.cookie);
+    },
+  });
+}

--- a/src/queue.js
+++ b/src/queue.js
@@ -1,20 +1,32 @@
-export const DEFAULT_JOB_OPTIONS = Object.freeze({
-  attempts: 3,
-  backoff: {
-    type: "exponential",
-    delay: 500,
-  },
-  removeOnComplete: {
-    age: 60 * 60,
-    count: 1000,
-  },
-  removeOnFail: {
-    age: 24 * 60 * 60,
-    count: 1000,
-  },
-});
+import { readFileSync } from "node:fs";
 
-export function redisConnectionOptions(redisUrl) {
+export function jobOptions(retentionSeconds = 24 * 60 * 60) {
+  return {
+    attempts: 3,
+    backoff: {
+      type: "exponential",
+      delay: 500,
+    },
+    removeOnComplete: {
+      age: retentionSeconds,
+      count: 1000,
+    },
+    removeOnFail: {
+      age: retentionSeconds,
+      count: 1000,
+    },
+  };
+}
+
+export function redisConnectionOptions(
+  redisUrl,
+  {
+    caFile = null,
+    certFile = null,
+    keyFile = null,
+  } = {},
+  readFile = readFileSync,
+) {
   const url = new URL(redisUrl);
   const options = {
     host: url.hostname,
@@ -32,7 +44,16 @@ export function redisConnectionOptions(redisUrl) {
     options.db = Number(url.pathname.slice(1));
   }
   if (url.protocol === "rediss:") {
-    options.tls = {};
+    options.tls = {
+      servername: url.hostname,
+    };
+    if (caFile) {
+      options.tls.ca = readFile(caFile);
+    }
+    if (certFile && keyFile) {
+      options.tls.cert = readFile(certFile);
+      options.tls.key = readFile(keyFile);
+    }
   }
 
   return options;

--- a/src/rate-limit.js
+++ b/src/rate-limit.js
@@ -1,0 +1,33 @@
+export function rateLimitKey(namespace, ownerKey, now, windowSeconds) {
+  const bucket = Math.floor(now / 1000 / windowSeconds);
+  return `${namespace}:rate:${ownerKey}:${bucket}`;
+}
+
+export async function consumeRateLimit(
+  redis,
+  {
+    namespace,
+    ownerKey,
+    limit,
+    windowSeconds,
+    now = Date.now(),
+  },
+) {
+  const resetAt = (Math.floor(now / 1000 / windowSeconds) + 1) * windowSeconds;
+  const key = rateLimitKey(namespace, ownerKey, now, windowSeconds);
+  const results = await redis
+    .multi()
+    .incr(key)
+    .expireat(key, resetAt + 1)
+    .exec();
+  const count = Number(results?.[0]?.[1]);
+  if (!Number.isInteger(count)) {
+    throw new Error("Rate limiter did not receive a valid Redis response");
+  }
+  return Object.freeze({
+    allowed: count <= limit,
+    limit,
+    remaining: Math.max(0, limit - count),
+    resetAt,
+  });
+}

--- a/src/session.js
+++ b/src/session.js
@@ -5,7 +5,6 @@ import {
 } from "node:crypto";
 
 export const SESSION_COOKIE_NAME = "notifier_session";
-export const SESSION_MAX_AGE_SECONDS = 60 * 60;
 
 function hmac(value, secret) {
   return createHmac("sha256", secret).update(value).digest("base64url");
@@ -79,14 +78,28 @@ export function createSession(secret) {
 }
 
 export function deriveNotificationRoom(sessionId, secret) {
-  return `session:${hmac(`room:${sessionId}`, secret)}`;
+  return deriveIdentityRoom("local", sessionId, secret);
 }
 
-export function serializeSessionCookie(token, { secure }) {
+export function deriveIdentityOwner(tenant, subject, secret) {
+  return hmac(`owner:${tenant}\0${subject}`, secret);
+}
+
+export function deriveIdentityRoom(tenant, subject, secret) {
+  return `identity:${hmac(`room:${tenant}\0${subject}`, secret)}`;
+}
+
+export function serializeSessionCookie(
+  token,
+  {
+    secure,
+    maxAgeSeconds = 24 * 60 * 60,
+  },
+) {
   const attributes = [
     `${SESSION_COOKIE_NAME}=${token}`,
     "Path=/",
-    `Max-Age=${SESSION_MAX_AGE_SECONDS}`,
+    `Max-Age=${maxAgeSeconds}`,
     "HttpOnly",
     "SameSite=Strict",
   ];

--- a/src/task-store.js
+++ b/src/task-store.js
@@ -1,0 +1,69 @@
+export class TaskStore {
+  constructor(
+    redis,
+    {
+      namespace,
+      retentionSeconds,
+    },
+  ) {
+    this.redis = redis;
+    this.namespace = namespace;
+    this.retentionSeconds = retentionSeconds;
+  }
+
+  indexKey(ownerKey) {
+    return `${this.namespace}:owner:${ownerKey}:tasks`;
+  }
+
+  acknowledgementKey(taskId) {
+    return `${this.namespace}:ack:${taskId}`;
+  }
+
+  async remember(ownerKey, taskId, now = Date.now()) {
+    const key = this.indexKey(ownerKey);
+    await this.redis
+      .multi()
+      .zadd(key, now, taskId)
+      .expire(key, this.retentionSeconds)
+      .exec();
+  }
+
+  async forget(ownerKey, taskId) {
+    await this.redis.zrem(this.indexKey(ownerKey), taskId);
+  }
+
+  async listTaskIds(ownerKey, limit, now = Date.now()) {
+    const key = this.indexKey(ownerKey);
+    const cutoff = now - this.retentionSeconds * 1000;
+    const transaction = await this.redis
+      .multi()
+      .zremrangebyscore(key, "-inf", cutoff)
+      .zrevrange(key, 0, limit - 1)
+      .expire(key, this.retentionSeconds)
+      .exec();
+    return transaction?.[1]?.[1] ?? [];
+  }
+
+  async acknowledgement(taskId) {
+    const value = await this.redis.get(this.acknowledgementKey(taskId));
+    return value ? JSON.parse(value) : null;
+  }
+
+  async acknowledge(taskId, now = Date.now()) {
+    const key = this.acknowledgementKey(taskId);
+    const acknowledgement = {
+      acknowledgedAt: new Date(now).toISOString(),
+    };
+    const stored = await this.redis.set(
+      key,
+      JSON.stringify(acknowledgement),
+      "EX",
+      this.retentionSeconds,
+      "NX",
+    );
+    if (stored) {
+      return acknowledgement;
+    }
+    return this.acknowledgement(taskId);
+  }
+}

--- a/src/task.js
+++ b/src/task.js
@@ -19,7 +19,11 @@ export function parseTaskMessage(body) {
   return message;
 }
 
-export async function presentJob(job) {
+export function isTerminalTask(status) {
+  return status === "completed" || status === "failed";
+}
+
+export async function presentJob(job, acknowledgement = null) {
   const rawState = await job.getState();
   const status = TASK_STATES.get(rawState) ?? "queued";
 
@@ -32,6 +36,9 @@ export async function presentJob(job) {
     createdAt: new Date(job.timestamp).toISOString(),
     result: status === "completed" ? job.returnvalue : null,
     error: status === "failed" ? "Task failed after all retry attempts." : null,
+    delivery: {
+      acknowledgedAt: acknowledgement?.acknowledgedAt ?? null,
+    },
   };
 }
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -30,6 +30,7 @@ export async function runDemoTask(job, { taskDelayMs }) {
 
 export async function createTaskWorker({
   redisUrl,
+  redisTls = {},
   queueName,
   eventChannel,
   taskDelayMs = 1200,
@@ -37,7 +38,9 @@ export async function createTaskWorker({
   processor = runDemoTask,
   logger = console,
 }) {
-  const publisher = new IORedis(redisUrl, {
+  const connection = redisConnectionOptions(redisUrl, redisTls);
+  const publisher = new IORedis({
+    ...connection,
     lazyConnect: true,
     maxRetriesPerRequest: null,
   });
@@ -61,7 +64,7 @@ export async function createTaskWorker({
     queueName,
     (job) => processor(job, { taskDelayMs }),
     {
-      connection: redisConnectionOptions(redisUrl),
+      connection,
       concurrency: workerConcurrency,
     },
   );

--- a/test/integration/notifier.test.js
+++ b/test/integration/notifier.test.js
@@ -59,20 +59,53 @@ function waitForSocket(socket, eventName, predicate = () => true) {
   });
 }
 
-async function waitForCompleted(url, cookie, taskId) {
+async function waitForTask(url, cookie, taskId, predicate) {
+  const headers =
+    typeof cookie === "string" ? { Cookie: cookie } : cookie;
   const deadline = Date.now() + 5000;
   while (Date.now() < deadline) {
     const response = await fetch(`${url}/api/tasks/${taskId}`, {
-      headers: { Cookie: cookie },
+      headers,
     });
     assert.equal(response.status, 200);
     const task = await response.json();
-    if (task.status === "completed") {
+    if (predicate(task)) {
       return task;
     }
     await new Promise((resolve) => setTimeout(resolve, 25));
   }
-  throw new Error("Task did not complete");
+  throw new Error("Task did not reach the expected state");
+}
+
+async function waitForCompleted(url, cookie, taskId) {
+  return waitForTask(
+    url,
+    cookie,
+    taskId,
+    (task) => task.status === "completed",
+  );
+}
+
+function expectNoSocketEvent(
+  socket,
+  eventName,
+  predicate,
+  durationMs = 250,
+) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      socket.off(eventName, onEvent);
+      resolve();
+    }, durationMs);
+    function onEvent(value) {
+      if (predicate(value)) {
+        clearTimeout(timeout);
+        socket.off(eventName, onEvent);
+        reject(new Error(`Unexpected ${eventName}`));
+      }
+    }
+    socket.on(eventName, onEvent);
+  });
 }
 
 integrationTest(
@@ -242,13 +275,230 @@ integrationTest(
     assert.equal(createResponse.status, 202);
     const created = await createResponse.json();
 
-    const task = await waitForCompleted(
+    const task = await waitForTask(
       url,
       sessionCookie,
       created.taskId,
+      (value) =>
+        value.status === "completed" &&
+        value.attemptsMade === 3,
     );
     assert.equal(processorCalls, 3);
     assert.equal(task.attemptsMade, 3);
     assert.equal(task.result.summary, "Recovered: retryable task");
+  },
+);
+
+integrationTest(
+  "OIDC identity replays unacknowledged work across devices and enforces limits",
+  async (context) => {
+    const suffix = randomUUID().replaceAll("-", "");
+    const tokenVerifier = async (token) => {
+      if (token === "invalid-token") {
+        throw new Error("invalid");
+      }
+      const exp = Math.floor(Date.now() / 1000) + 300;
+      if (token === "expiring-token") {
+        return {
+          payload: {
+            sub: "user-1",
+            tenant_id: "tenant-a",
+            exp: Math.floor(Date.now() / 1000) + 1,
+          },
+        };
+      }
+      const identities = {
+        "first-token": { sub: "user-1", tenant_id: "tenant-a", exp },
+        "refreshed-token": { sub: "user-1", tenant_id: "tenant-a", exp },
+        "other-user": { sub: "user-2", tenant_id: "tenant-a", exp },
+        "other-tenant": { sub: "user-1", tenant_id: "tenant-b", exp },
+      };
+      return { payload: identities[token] };
+    };
+    const shared = {
+      redisUrl,
+      queueName: `notifier-oidc-${suffix}`,
+      eventChannel: `notifier-oidc-${suffix}:events`,
+      sessionSecret: "oidc-test-secret-that-is-at-least-32-bytes",
+      publicOrigin: null,
+      isProduction: false,
+      authMode: "oidc",
+      oidcTenantClaim: "tenant_id",
+      tokenVerifier,
+      taskRateLimit: 2,
+      taskRateWindowSeconds: 60,
+      taskRetentionSeconds: 600,
+      logger,
+    };
+    const api = await createNotifierApi({ ...shared, port: 0 });
+    const worker = await createTaskWorker({
+      ...shared,
+      taskDelayMs: 30,
+      workerConcurrency: 1,
+    });
+    const url = baseUrl(await api.start());
+    const authorization = {
+      Authorization: "Bearer first-token",
+    };
+    const refreshedAuthorization = {
+      Authorization: "Bearer refreshed-token",
+    };
+    const sockets = [];
+
+    context.after(async () => {
+      for (const socket of sockets) {
+        socket.disconnect();
+      }
+      await api.queue.obliterate({ force: true });
+      await Promise.all([worker.close(), api.close()]);
+    });
+
+    const createResponse = await fetch(`${url}/api/tasks`, {
+      method: "POST",
+      headers: {
+        ...authorization,
+        Origin: url,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ message: "cross-device task" }),
+    });
+    assert.equal(createResponse.status, 202);
+    const created = await createResponse.json();
+    const completed = await waitForCompleted(
+      url,
+      authorization,
+      created.taskId,
+    );
+    assert.equal(completed.delivery.acknowledgedAt, null);
+
+    const reconnected = createSocketClient(url, {
+      autoConnect: false,
+      auth: { token: "refreshed-token" },
+      extraHeaders: { Origin: url },
+      transports: ["websocket"],
+    });
+    sockets.push(reconnected);
+    const replayed = waitForSocket(
+      reconnected,
+      "task:update",
+      (event) => event.taskId === created.taskId && event.replayed === true,
+    );
+    reconnected.connect();
+    await replayed;
+
+    const acknowledgementResponse = await fetch(
+      `${url}/api/tasks/${created.taskId}/ack`,
+      {
+        method: "POST",
+        headers: {
+          ...refreshedAuthorization,
+          Origin: url,
+        },
+      },
+    );
+    assert.equal(acknowledgementResponse.status, 200);
+    const acknowledgement = await acknowledgementResponse.json();
+    assert.match(
+      acknowledgement.delivery.acknowledgedAt,
+      /^\d{4}-\d{2}-\d{2}T/,
+    );
+    const repeatedAcknowledgement = await fetch(
+      `${url}/api/tasks/${created.taskId}/ack`,
+      {
+        method: "POST",
+        headers: {
+          ...refreshedAuthorization,
+          Origin: url,
+        },
+      },
+    );
+    assert.equal(repeatedAcknowledgement.status, 200);
+    assert.equal(
+      (await repeatedAcknowledgement.json()).delivery.acknowledgedAt,
+      acknowledgement.delivery.acknowledgedAt,
+    );
+
+    for (const token of ["other-user", "other-tenant"]) {
+      const forbidden = await fetch(`${url}/api/tasks/${created.taskId}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      assert.equal(forbidden.status, 404);
+    }
+
+    const recentResponse = await fetch(`${url}/api/tasks`, {
+      headers: refreshedAuthorization,
+    });
+    assert.equal(recentResponse.status, 200);
+    const recent = await recentResponse.json();
+    assert.equal(recent.tasks[0].taskId, created.taskId);
+    assert.equal(
+      recent.tasks[0].delivery.acknowledgedAt,
+      acknowledgement.delivery.acknowledgedAt,
+    );
+
+    const secondResponse = await fetch(`${url}/api/tasks`, {
+      method: "POST",
+      headers: {
+        ...refreshedAuthorization,
+        Origin: url,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ message: "within limit" }),
+    });
+    assert.equal(secondResponse.status, 202);
+    const limitedResponse = await fetch(`${url}/api/tasks`, {
+      method: "POST",
+      headers: {
+        ...authorization,
+        Origin: url,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ message: "over limit" }),
+    });
+    assert.equal(limitedResponse.status, 429);
+    assert.equal(limitedResponse.headers.get("x-ratelimit-remaining"), "0");
+    assert.ok(Number(limitedResponse.headers.get("retry-after")) >= 1);
+
+    reconnected.disconnect();
+    const afterAck = createSocketClient(url, {
+      autoConnect: false,
+      auth: { token: "refreshed-token" },
+      extraHeaders: { Origin: url },
+      transports: ["websocket"],
+    });
+    sockets.push(afterAck);
+    const ready = waitForSocket(afterAck, "notifier:ready");
+    const noAcknowledgedReplay = expectNoSocketEvent(
+      afterAck,
+      "task:update",
+      (event) => event.taskId === created.taskId,
+    );
+    afterAck.connect();
+    await ready;
+    await noAcknowledgedReplay;
+
+    const unauthenticated = await fetch(`${url}/api/tasks`);
+    assert.equal(unauthenticated.status, 401);
+    assert.equal(
+      unauthenticated.headers.get("www-authenticate"),
+      "Bearer",
+    );
+
+    const expiring = createSocketClient(url, {
+      autoConnect: false,
+      auth: { token: "expiring-token" },
+      extraHeaders: { Origin: url },
+      transports: ["websocket"],
+    });
+    sockets.push(expiring);
+    const expiringConnected = waitForSocket(expiring, "connect");
+    const expiredDisconnect = waitForSocket(
+      expiring,
+      "disconnect",
+      (reason) => reason === "io server disconnect",
+    );
+    expiring.connect();
+    await expiringConnected;
+    await expiredDisconnect;
   },
 );

--- a/test/unit/config.test.js
+++ b/test/unit/config.test.js
@@ -8,6 +8,17 @@ const VALID_ENV = {
   PUBLIC_ORIGIN: "http://localhost:3000",
 };
 
+const PRODUCTION_ENV = {
+  ...VALID_ENV,
+  NODE_ENV: "production",
+  AUTH_MODE: "oidc",
+  PUBLIC_ORIGIN: "https://notifier.example",
+  REDIS_URL: "rediss://notifier-user:password@redis.example:6380/0",
+  OIDC_ISSUER: "https://identity.example/",
+  OIDC_AUDIENCE: "https://notifier.example/api",
+  OIDC_JWKS_URL: "https://identity.example/.well-known/jwks.json",
+};
+
 test("loadConfig applies safe tutorial defaults", () => {
   const config = loadConfig(VALID_ENV);
 
@@ -15,6 +26,9 @@ test("loadConfig applies safe tutorial defaults", () => {
   assert.equal(config.host, "127.0.0.1");
   assert.equal(config.redisUrl, "redis://localhost:6379");
   assert.equal(config.workerConcurrency, 4);
+  assert.equal(config.taskRetentionSeconds, 86400);
+  assert.equal(config.taskRateLimit, 30);
+  assert.equal(config.authMode, "anonymous");
   assert.equal(config.isProduction, false);
 });
 
@@ -56,15 +70,69 @@ test("loadConfig rejects a non-numeric Redis database", () => {
 
 test("loadConfig requires HTTPS in production", () => {
   assert.throws(
-    () => loadConfig({ ...VALID_ENV, NODE_ENV: "production" }),
+    () =>
+      loadConfig({
+        ...PRODUCTION_ENV,
+        PUBLIC_ORIGIN: "http://notifier.example",
+      }),
     /must use https/,
   );
-  assert.equal(
-    loadConfig({
-      ...VALID_ENV,
-      NODE_ENV: "production",
-      PUBLIC_ORIGIN: "https://notifier.example",
-    }).isProduction,
-    true,
+  assert.equal(loadConfig(PRODUCTION_ENV).isProduction, true);
+});
+
+test("production requires OIDC plus ACL-authenticated Redis TLS", () => {
+  assert.throws(
+    () => loadConfig({ ...PRODUCTION_ENV, AUTH_MODE: "anonymous" }),
+    /AUTH_MODE must be oidc/,
+  );
+  assert.throws(
+    () =>
+      loadConfig({
+        ...PRODUCTION_ENV,
+        REDIS_URL: "redis://redis.example:6379",
+      }),
+    /rediss.*ACL username and password/,
+  );
+  assert.throws(
+    () =>
+      loadConfig({
+        ...PRODUCTION_ENV,
+        REDIS_URL: "rediss://redis.example:6380",
+      }),
+    /ACL username and password/,
+  );
+});
+
+test("OIDC and retention settings are bounded", () => {
+  const config = loadConfig({
+    ...PRODUCTION_ENV,
+    OIDC_ALGORITHMS: "RS256,ES256",
+    OIDC_TENANT_CLAIM: "org.id",
+    TASK_RETENTION_SECONDS: "7200",
+    TASK_RATE_LIMIT: "12",
+  });
+  assert.deepEqual(config.oidcAlgorithms, ["RS256", "ES256"]);
+  assert.equal(config.oidcTenantClaim, "org.id");
+  assert.equal(config.taskRetentionSeconds, 7200);
+  assert.equal(config.taskRateLimit, 12);
+
+  assert.throws(
+    () => loadConfig({ ...PRODUCTION_ENV, OIDC_ALGORITHMS: "HS256" }),
+    /subset of RS256/,
+  );
+  assert.throws(
+    () => loadConfig({ ...PRODUCTION_ENV, TASK_RETENTION_SECONDS: "299" }),
+    /between 300/,
+  );
+});
+
+test("Redis client certificates require a matching private key", () => {
+  assert.throws(
+    () =>
+      loadConfig({
+        ...VALID_ENV,
+        REDIS_CERT_FILE: "/run/secrets/client.pem",
+      }),
+    /configured together/,
   );
 });

--- a/test/unit/identity.test.js
+++ b/test/unit/identity.test.js
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createLocalJWKSet,
+  exportJWK,
+  generateKeyPair,
+  SignJWT,
+} from "jose";
+
+import {
+  createIdentityService,
+  createOidcTokenVerifier,
+} from "../../src/identity.js";
+
+const SECRET = "identity-test-secret-that-is-at-least-32-bytes";
+
+test("anonymous identity persists through the signed tutorial cookie", async () => {
+  let cookie;
+  const identities = createIdentityService({
+    authMode: "anonymous",
+    sessionSecret: SECRET,
+    taskRetentionSeconds: 600,
+  });
+  const first = await identities.authenticateRequest(
+    { headers: {} },
+    {
+      setHeader(name, value) {
+        assert.equal(name, "Set-Cookie");
+        cookie = value.split(";", 1)[0];
+      },
+    },
+  );
+  const second = await identities.authenticateSocket({
+    request: { headers: { cookie } },
+    handshake: {},
+  });
+
+  assert.equal(first.ownerKey, second.ownerKey);
+  assert.equal(first.notificationRoom, second.notificationRoom);
+  assert.doesNotMatch(cookie, new RegExp(first.ownerKey));
+});
+
+test("OIDC identity is stable across tokens and isolated by tenant", async () => {
+  const identities = createIdentityService({
+    authMode: "oidc",
+    sessionSecret: SECRET,
+    oidcTenantClaim: "tenant_id",
+    tokenVerifier: async (token) => ({
+      payload:
+        token === "tenant-b"
+          ? {
+              sub: "user-1",
+              tenant_id: "tenant-b",
+              exp: Math.floor(Date.now() / 1000) + 300,
+            }
+          : {
+              sub: "user-1",
+              tenant_id: "tenant-a",
+              exp: Math.floor(Date.now() / 1000) + 300,
+            },
+    }),
+  });
+  const first = await identities.authenticateRequest(
+    { headers: { authorization: "Bearer first-token" } },
+    {},
+  );
+  const refreshed = await identities.authenticateSocket({
+    request: { headers: {} },
+    handshake: { auth: { token: "refreshed-token" } },
+  });
+  const otherTenant = await identities.authenticateRequest(
+    { headers: { authorization: "Bearer tenant-b" } },
+    {},
+  );
+
+  assert.equal(first.ownerKey, refreshed.ownerKey);
+  assert.equal(first.notificationRoom, refreshed.notificationRoom);
+  assert.notEqual(first.ownerKey, otherTenant.ownerKey);
+  await assert.rejects(
+    identities.authenticateRequest({ headers: {} }, {}),
+    /Authentication is required/,
+  );
+});
+
+test("OIDC failures are returned as generic authentication errors", async () => {
+  const identities = createIdentityService({
+    authMode: "oidc",
+    sessionSecret: SECRET,
+    tokenVerifier: async () => {
+      throw new Error("provider-specific validation details");
+    },
+  });
+
+  await assert.rejects(
+    identities.authenticateRequest(
+      { headers: { authorization: "Bearer invalid-token" } },
+      {},
+    ),
+    (error) =>
+      error.statusCode === 401 &&
+      error.message === "The access token is invalid or expired.",
+  );
+});
+
+test("OIDC verifier pins algorithm, issuer, audience, and identity claims", async () => {
+  const { privateKey, publicKey } = await generateKeyPair("RS256");
+  const publicJwk = await exportJWK(publicKey);
+  publicJwk.kid = "test-key";
+  publicJwk.alg = "RS256";
+  const verifier = createOidcTokenVerifier({
+    issuer: "https://identity.example/",
+    audience: "notifier-api",
+    algorithms: ["RS256"],
+    tenantClaim: "tenant_id",
+    keySet: createLocalJWKSet({ keys: [publicJwk] }),
+  });
+  const validToken = await new SignJWT({
+    tenant_id: "tenant-a",
+  })
+    .setProtectedHeader({ alg: "RS256", kid: "test-key", typ: "at+jwt" })
+    .setIssuer("https://identity.example/")
+    .setAudience("notifier-api")
+    .setSubject("user-1")
+    .setIssuedAt()
+    .setExpirationTime("5m")
+    .sign(privateKey);
+  const wrongAudience = await new SignJWT({
+    tenant_id: "tenant-a",
+  })
+    .setProtectedHeader({ alg: "RS256", kid: "test-key", typ: "at+jwt" })
+    .setIssuer("https://identity.example/")
+    .setAudience("another-api")
+    .setSubject("user-1")
+    .setIssuedAt()
+    .setExpirationTime("5m")
+    .sign(privateKey);
+
+  assert.equal((await verifier(validToken)).payload.sub, "user-1");
+  await assert.rejects(verifier(wrongAudience), /aud/);
+});

--- a/test/unit/queue.test.js
+++ b/test/unit/queue.test.js
@@ -2,22 +2,30 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
-  DEFAULT_JOB_OPTIONS,
+  jobOptions,
   redisConnectionOptions,
 } from "../../src/queue.js";
 
 test("jobs use bounded retries and retention", () => {
-  assert.deepEqual(DEFAULT_JOB_OPTIONS.backoff, {
+  const options = jobOptions(7200);
+  assert.deepEqual(options.backoff, {
     type: "exponential",
     delay: 500,
   });
-  assert.equal(DEFAULT_JOB_OPTIONS.attempts, 3);
-  assert.equal(DEFAULT_JOB_OPTIONS.removeOnComplete.age, 3600);
+  assert.equal(options.attempts, 3);
+  assert.equal(options.removeOnComplete.age, 7200);
+  assert.equal(options.removeOnFail.age, 7200);
 });
 
-test("Redis URL parsing preserves credentials without logging them", () => {
+test("Redis URL parsing preserves credentials and loads TLS files", () => {
   const options = redisConnectionOptions(
     "rediss://queue-user:p%40ss@example.test:6380/2",
+    {
+      caFile: "/secrets/ca.pem",
+      certFile: "/secrets/client.pem",
+      keyFile: "/secrets/client-key.pem",
+    },
+    (file) => Buffer.from(file),
   );
 
   assert.equal(options.host, "example.test");
@@ -25,6 +33,9 @@ test("Redis URL parsing preserves credentials without logging them", () => {
   assert.equal(options.username, "queue-user");
   assert.equal(options.password, "p@ss");
   assert.equal(options.db, 2);
-  assert.deepEqual(options.tls, {});
+  assert.equal(options.tls.servername, "example.test");
+  assert.equal(options.tls.ca.toString(), "/secrets/ca.pem");
+  assert.equal(options.tls.cert.toString(), "/secrets/client.pem");
+  assert.equal(options.tls.key.toString(), "/secrets/client-key.pem");
   assert.equal(options.maxRetriesPerRequest, null);
 });

--- a/test/unit/rate-limit.test.js
+++ b/test/unit/rate-limit.test.js
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { rateLimitKey } from "../../src/rate-limit.js";
+
+test("rate-limit keys are scoped by namespace, owner, and fixed window", () => {
+  assert.equal(
+    rateLimitKey("notifier", "owner-a", 61_000, 60),
+    "notifier:rate:owner-a:1",
+  );
+  assert.notEqual(
+    rateLimitKey("notifier", "owner-a", 61_000, 60),
+    rateLimitKey("notifier", "owner-b", 61_000, 60),
+  );
+  assert.notEqual(
+    rateLimitKey("notifier", "owner-a", 61_000, 60),
+    rateLimitKey("notifier", "owner-a", 121_000, 60),
+  );
+});

--- a/test/unit/session.test.js
+++ b/test/unit/session.test.js
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   createSession,
+  deriveIdentityOwner,
   deriveNotificationRoom,
   readSessionId,
   serializeSessionCookie,
@@ -42,6 +43,22 @@ test("cookie parsing and room derivation do not expose socket IDs", () => {
   );
 
   const room = deriveNotificationRoom(sessionId, SECRET);
-  assert.match(room, /^session:[A-Za-z0-9_-]{43}$/);
+  assert.match(room, /^identity:[A-Za-z0-9_-]{43}$/);
   assert.doesNotMatch(room, new RegExp(sessionId));
+});
+
+test("tenant and subject derive stable, isolated owner keys", () => {
+  const first = deriveIdentityOwner("tenant-a", "user-1", SECRET);
+  assert.equal(
+    first,
+    deriveIdentityOwner("tenant-a", "user-1", SECRET),
+  );
+  assert.notEqual(
+    first,
+    deriveIdentityOwner("tenant-b", "user-1", SECRET),
+  );
+  assert.notEqual(
+    first,
+    deriveIdentityOwner("tenant-a", "user-2", SECRET),
+  );
 });

--- a/test/unit/task.test.js
+++ b/test/unit/task.test.js
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  isTerminalTask,
   parseTaskMessage,
   publicTaskEvent,
 } from "../../src/task.js";
@@ -44,4 +45,11 @@ test("invalid task events are ignored", () => {
     }),
     null,
   );
+});
+
+test("only completed and failed tasks are terminal acknowledgements", () => {
+  assert.equal(isTerminalTask("completed"), true);
+  assert.equal(isTerminalTask("failed"), true);
+  assert.equal(isTerminalTask("running"), false);
+  assert.equal(isTerminalTask("queued"), false);
 });


### PR DESCRIPTION
## What changed

- Add two explicit identity modes: signed anonymous sessions for the local lab and OIDC/JWT access-token validation for production.
- Validate production tokens against a fixed JWKS URL with a pinned asymmetric algorithm allowlist plus exact issuer, audience, expiration, subject, and tenant claims.
- Derive opaque owner/room keys from validated tenant and subject claims so refreshed tokens and other devices for the same identity can recover work without storing raw claims.
- Index recent tasks, replay unacknowledged terminal tasks on reconnect, and add an idempotent `POST /api/tasks/:id/ack` receipt.
- Add Redis-backed per-identity task creation limits and configurable bounded retention shared by jobs, owner indexes, and acknowledgements.
- Require production HTTPS, `AUTH_MODE=oidc`, and `rediss://` with an ACL username/password; support private CA and mutual-TLS certificate files.
- Pin the Redis image digest and add a least-privilege GitHub Actions workflow using current official action commits and a Redis service container.
- Expand the UI, tutorial, architecture notes, and a new production operations guide with identity, client, Redis ACL/TLS, delivery, health, scaling, and pre-deployment contracts.

Closes #1.

## Why

The modernization made same-browser recovery durable, but issue #1 specifically asked for a stable user grouping and redelivery after a different socket reconnects. A socket ID cannot provide that guarantee. This change binds ownership to provider-validated tenant and subject claims, persists pending delivery state independently from the socket, and makes receipt explicit without inventing a password or tenant database inside the sample.

## Security and operational impact

Production startup now fails closed if anonymous auth, HTTP origin, plaintext Redis, or password-only Redis without a named ACL user is configured. Access tokens, raw identity claims, Redis credentials, and certificate contents are not persisted or logged. Socket connections are disconnected when their validated token expires.

The repository remains a provider-neutral starter, not a deployment. Login/MFA/consent/token issuance and revocation, tenant membership policy, TLS termination, secret injection, managed Redis, backup/restore, monitoring, capacity, data classification, and compliance retention remain operator responsibilities documented in `docs/production.md`.

## Validation

Exact candidate: `aaa75e1b64bef8844df0929c672cbd5c0d0b405e`

- Exact Node 24.18.0 Compose gate: 24 unit and 3 Redis-backed integration tests passed.
- Integration proves two-API fan-out, missed-event recovery, retry persistence, refreshed-token/cross-device replay, tenant and user isolation, idempotent acknowledgement, acknowledgement replay suppression, shared rate limiting across refreshed tokens, and token-expiry socket disconnect.
- `npm audit --omit=dev --audit-level=high`: 0 vulnerabilities.
- Production image/runtime smoke: Redis, API, and worker healthy; end-to-end task/list/ack passed; API remained non-root, read-only, capability-dropped, and loopback-only.
- Browser smoke: completed task exposed `Mark seen`, acknowledgement changed to disabled `Seen`, reload preserved the task and receipt, and console warnings/errors were empty.
- Workflow YAML parsing, `docker compose config --quiet`, syntax checks, secret-pattern scan, and `git diff --check` passed.

The new GitHub Actions workflow will provide its first hosted evidence on this PR. It has read-only repository permissions and contains no deployment or publication job. No cloud infrastructure was deployed and no paid resource was created.

## Release

After a clean merge and exact-default retest, this change is intended for the explicitly authorized `v2.0.0` GitHub release.
