### PR TITLE
Finish notifier tutorial test coverage

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -138,14 +138,25 @@ rate limiting.
 That is a bounded functional proof of the sample's scale-out design. It is not
 a load, chaos, or production failover test.
 
-## 6. Read the retry policy
+## 6. Prove retries recover—or stop
 
 `src/queue.js` gives each job three attempts with exponential backoff. In
 BullMQ, a worker exception moves the job through the retry policy; the final
 failure is retained for inspection and emitted as a generic browser update.
 
 The sample processor only waits and returns a string, so the interactive path
-does not intentionally fail. In a real processor:
+does not intentionally fail. The integration test uses local-only deterministic
+processors instead: one fails twice and succeeds on the third attempt; another
+fails all three attempts. Run it with the Compose test command from step 5 and
+inspect `worker failures use the configured exponential retry policy` in
+`test/integration/notifier.test.js`.
+
+The recovered task preserves `attemptsMade: 3`. The exhausted task preserves a
+generic terminal error without exposing the processor's internal exception.
+This proves the bounded retry and failure-state contract without adding a
+magic failure command to the public API.
+
+In a real processor:
 
 - throw an `Error` for a retryable failure;
 - make the operation idempotent or use an idempotency key;

--- a/test/integration/notifier.test.js
+++ b/test/integration/notifier.test.js
@@ -237,14 +237,18 @@ integrationTest(
       isProduction: false,
       logger,
     };
-    let processorCalls = 0;
+    const processorCalls = new Map();
 
     const api = await createNotifierApi({ ...shared, port: 0 });
     const worker = await createTaskWorker({
       ...shared,
       processor: async (job) => {
-        processorCalls += 1;
-        if (processorCalls < 3) {
+        const calls = (processorCalls.get(job.id) ?? 0) + 1;
+        processorCalls.set(job.id, calls);
+        if (
+          job.data.message === "permanent failure" ||
+          calls < 3
+        ) {
           throw new Error("synthetic retryable failure");
         }
         return {
@@ -283,9 +287,36 @@ integrationTest(
         value.status === "completed" &&
         value.attemptsMade === 3,
     );
-    assert.equal(processorCalls, 3);
+    assert.equal(processorCalls.get(created.taskId), 3);
     assert.equal(task.attemptsMade, 3);
     assert.equal(task.result.summary, "Recovered: retryable task");
+
+    const failedResponse = await fetch(`${url}/api/tasks`, {
+      method: "POST",
+      headers: {
+        Cookie: sessionCookie,
+        Origin: url,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ message: "permanent failure" }),
+    });
+    assert.equal(failedResponse.status, 202);
+    const failed = await failedResponse.json();
+
+    const exhausted = await waitForTask(
+      url,
+      sessionCookie,
+      failed.taskId,
+      (value) =>
+        value.status === "failed" &&
+        value.attemptsMade === 3,
+    );
+    assert.equal(processorCalls.get(failed.taskId), 3);
+    assert.equal(exhausted.result, null);
+    assert.equal(
+      exhausted.error,
+      "Task failed after all retry attempts.",
+    );
   },
 );
 

--- a/test/unit/tutorial-assets.test.js
+++ b/test/unit/tutorial-assets.test.js
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import test from "node:test";
+
+const repositoryRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+
+async function readPublicAsset(name) {
+  return readFile(path.join(repositoryRoot, "public", name), "utf8");
+}
+
+test("tutorial page keeps its durable-notification teaching surface intact", async () => {
+  const html = await readPublicAsset("index.html");
+
+  for (const snippet of [
+    '<form id="task-form">',
+    'id="task-message"',
+    'maxlength="120"',
+    '<ol id="task-list" class="task-list" aria-live="polite">',
+    '<template id="task-template">',
+    '<button class="task__ack" type="button"',
+  ]) {
+    assert.match(html, new RegExp(snippet.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  }
+
+  assert.match(html, /<script src="\/socket\.io\/socket\.io\.js"><\/script>/);
+  assert.match(html, /<script src="\/app\.js"><\/script>/);
+  assert.match(html, /Start a job\. Leave the page\. Come back to the result\./);
+});
+
+test("tutorial client stays same-origin and does not embed production endpoints", async () => {
+  const client = await readPublicAsset("app.js");
+
+  assert.doesNotMatch(client, /https?:\/\//i);
+  assert.match(client, /fetch\("\/api\/tasks"/);
+  assert.match(client, /io\(\{\s*transports: \["websocket"\]/s);
+  assert.match(client, /localStorage/);
+});


### PR DESCRIPTION
## What changed

- guard the tutorial UI and same-origin browser contract with unit tests
- make the Redis integration scenario prove both third-attempt recovery and exhausted retries
- explain the deterministic failure fixtures and generic terminal error in the guided tutorial

## Why

The existing v2 replacement is already merged and functional, but its browser teaching surface was unguarded and the documentation claimed retry exhaustion coverage that the integration test did not actually exercise. This closes both evidence gaps without adding a magic failure input to the public API.

## Validation

- `npm test` — 26/26 passed
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- isolated Node 24 Compose test — 26 unit + 3 Redis integration tests passed
- isolated runtime Compose smoke — readiness, tutorial asset, queued task completion, and graceful API/worker SIGTERM passed
- `docker compose config --quiet`
- scoped secret/privacy scan — only documented synthetic values and placeholders
