### PR TITLE
Document notifier migration and rollback

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,6 @@
 .gitignore
 .env
 coverage
-docs
 node_modules
 npm-debug.log*
 sequence diagram 1.png

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+Notable repository changes are documented here. This project follows semantic
+versioning for tagged v2 releases; the original tutorial did not publish
+semantic release tags.
+
+## Unreleased
+
+### Added
+
+- A browser-asset contract test that preserves the tutorial form, task list,
+  acknowledgement control, same-origin API, WebSocket, and recovery surface.
+- Deterministic integration coverage for third-attempt recovery and exhausted
+  retries without exposing a magic failure command in the public API.
+- Migration, cutover, rollback, privacy, data-handling, and vulnerability
+  reporting guidance.
+
+### Changed
+
+- The guided tutorial now explains both retry recovery and terminal failure
+  evidence.
+
+## 2.0.0 - 2026-07-27
+
+### Added
+
+- One Node 24 API/worker codebase with pinned dependencies, lockfile, current
+  Compose, health checks, graceful shutdown, and non-root read-only containers.
+- BullMQ durable jobs, bounded retries, saved task state, cross-instance live
+  hints, recent-task recovery, and idempotent acknowledgement.
+- Signed anonymous tutorial sessions and production OIDC/JWT identity with
+  stable tenant-and-subject ownership.
+- Redis-backed per-identity rate limits, bounded retention, Redis TLS/ACL
+  validation, unit tests, hermetic Redis integration tests, and least-privilege
+  GitHub Actions CI.
+- A same-origin browser lab, guided tutorial, architecture analysis, and
+  production operations guide.
+
+### Removed
+
+- Node 4 and Redis 2.8 assumptions, legacy Compose v2, public Redis/notifier
+  ports, unauthenticated `/notify`, and socket IDs in task routing.
+- Redis Pub/Sub as the work queue. Pub/Sub now carries only an optional
+  low-latency update.
+
+## Legacy demo - 2016
+
+- Introduced the concise browser, web server, Redis, worker, and notifier
+  teaching flow.
+- Documented the horizontal-scaling and browser-refresh problems but left them
+  unresolved.
+- The final pre-modernization default snapshot is `4ec72a8`; it is historical
+  source, not a supported release or rollback target.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,21 @@ The [guided tutorial](docs/tutorial.md) walks through:
 - the exact security boundary of the anonymous demo session; and
 - the provider-neutral production identity contract.
 
+## Adopt or evaluate it
+
+- [Architecture notes](docs/architecture.md) preserve the original teaching
+  intent and explain why the 2016 design is obsolete.
+- [Migration and rollback](docs/migration.md) maps the old contracts to v2 and
+  gives a cutover and recovery procedure.
+- [Production guide](docs/production.md) defines the identity, Redis, delivery,
+  scaling, and pre-deployment boundaries.
+- [Privacy and data handling](docs/privacy.md) inventories stored and transient
+  data, retention limits, and safe tutorial inputs.
+- [Security policy](SECURITY.md) describes supported versions and private
+  vulnerability reporting.
+- [Changelog](CHANGELOG.md) separates the legacy demo, v2 release, and
+  unreleased safeguards.
+
 ## Validate
 
 Unit tests need Node 24:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,48 @@
+# Security policy
+
+## Supported versions
+
+| Version | Security fixes |
+| --- | --- |
+| Current `master` and the latest v2 release | Supported |
+| 2016 legacy demo | Unsupported |
+
+The legacy demo uses end-of-life runtimes, treats a socket ID as authorization,
+publishes internal services to the host, and has lossy task and notification
+paths. It should not be deployed.
+
+## Report a vulnerability
+
+Do not open a public issue with an undisclosed vulnerability, exploit,
+credential, token, private certificate, Redis dump, or real task payload.
+
+Use GitHub's private vulnerability-reporting flow from the repository's
+**Security** tab when it is available. If that flow is unavailable, contact
+the repository owner through the GitHub profile without sending exploit
+details or sensitive data until a private channel is agreed.
+
+Include only synthetic evidence:
+
+- the affected commit or release;
+- the component and configuration mode;
+- minimum reproduction steps;
+- expected and observed behavior;
+- likely impact and prerequisites; and
+- a proposed mitigation, if known.
+
+There is no guaranteed response or remediation service-level agreement for
+this educational repository. Do not test against systems you do not own or
+have explicit authorization to assess.
+
+## Security boundary
+
+The local lab is intentionally loopback-only and uses anonymous signed
+sessions. Production mode requires external OIDC identity, HTTPS origin, and
+ACL-authenticated Redis TLS, but it remains a starter. The operator owns TLS
+termination, authorization policy, secrets, dependency updates, network
+controls, capacity, backups, monitoring, incident response, and safe worker
+side effects.
+
+Review [the production guide](docs/production.md),
+[privacy and data handling](docs/privacy.md), and
+[migration and rollback](docs/migration.md) before adapting the sample.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,116 @@
+# Migration and rollback guide
+
+The 2016 repository is a useful architecture sketch, not a safe deployment
+target. This guide helps an adopter move the lesson or an adapted service to
+the v2 contract without treating a socket connection as identity or Redis
+Pub/Sub as durable storage.
+
+The last pre-modernization default-branch snapshot is commit `4ec72a8`. It is
+useful for source comparison only: its clean-clone container path does not
+install dependencies, its runtimes are end-of-life, and its task and
+notification paths can lose work.
+
+## Compatibility boundary
+
+This is a replacement, not an in-place dependency upgrade.
+
+| Legacy contract | v2 contract | Required migration |
+| --- | --- | --- |
+| Three Node services plus Redis | API, durable queue, and worker | Deploy API and worker from one versioned artifact |
+| `socketId` crosses every service | Server-derived owner and notification room | Remove socket IDs from public and worker payloads |
+| Redis `PUBLISH` is the work queue | BullMQ stores jobs and terminal state | Use a new queue namespace; do not reinterpret old messages |
+| Worker calls unauthenticated `/notify` | Worker saves state, then publishes a live hint | Remove public notifier credentials and routing |
+| Browser waits for one socket event | Browser reads task state on load, reconnect, and event | Add task list/read and acknowledgement handling |
+| No stable identity | Signed local session or validated OIDC tenant and subject | Choose the identity boundary before production cutover |
+| Host-published Redis | Private Redis with production TLS and ACLs | Provision and validate the datastore boundary |
+
+Legacy socket IDs, Pub/Sub messages, and in-flight work have no compatible v2
+representation. Do not point v2 at a legacy Redis database and assume those
+items were migrated. Drain or explicitly abandon legacy work according to the
+product's recovery policy.
+
+## Application migration
+
+1. Inventory every producer, worker operation, browser client, retention
+   requirement, and notification claim. Decide what a completed, failed, and
+   acknowledged task means for the product.
+2. Make the real worker operation idempotent. BullMQ can redeliver a job after
+   a failure or stalled lock; retries do not make side effects safe.
+3. Give the v2 queue, indexes, rate limits, and event channel a dedicated Redis
+   namespace. Configure private networking, TLS, a named ACL user, capacity,
+   backups, restore exercises, and monitoring.
+4. Select production identity claims. Configure one issuer, audience, JWKS
+   URL, asymmetric algorithm allowlist, tenant claim, and an authorization
+   policy that verifies tenant membership.
+5. Replace client use of `socketId` with the v2 API:
+   - create work with `POST /api/tasks`;
+   - recover state with `GET /api/tasks` and `GET /api/tasks/:id`;
+   - treat `task:update` as a prompt to reread saved state; and
+   - acknowledge terminal state with `POST /api/tasks/:id/ack`.
+6. Exercise token refresh and a second device for the same identity, plus
+   cross-user and cross-tenant denial. Do not place access tokens in URLs,
+   logs, local storage, or task messages.
+7. Choose retention, rate limits, replay size, and worker concurrency from
+   product and operational requirements. The sample defaults are not a
+   compliance decision or capacity plan.
+
+Read [the production guide](production.md) and
+[privacy and data handling](privacy.md) before adapting the tutorial to real
+data.
+
+## Cutover
+
+Use a parallel, observable cutover rather than changing the legacy queue in
+place:
+
+1. Deploy an immutable v2 candidate with a new queue namespace and no public
+   traffic.
+2. Run unit, Redis integration, container, security, and failure tests against
+   that exact artifact.
+3. Submit synthetic tasks through the intended ingress and prove queueing,
+   completion, reconnect recovery, acknowledgement, health, and logs.
+4. Stop legacy task creation. Let legacy workers drain or record every item
+   that the owner deliberately abandons.
+5. Route a bounded share of new traffic to v2 while watching API readiness,
+   queue age, retries, terminal failures, Redis capacity, and WebSocket
+   disconnects.
+6. Complete the cutover only after the rollback target and datastore snapshot
+   are still usable.
+
+No step in this repository deploys infrastructure or migrates production data.
+
+## Rollback
+
+Rollback means returning traffic to a previously validated v2 artifact and
+configuration. Do **not** roll production traffic back to the 2016 stack: it
+cannot safely read v2 jobs, does not provide stable authorization, and can lose
+both tasks and notifications.
+
+1. Stop or rate-limit new task creation while preserving reads.
+2. Record the candidate image or commit, configuration version, queue
+   namespace, and counts of waiting, active, completed, and failed work.
+3. Keep compatible v2 workers available to drain already accepted jobs. Never
+   send v2 jobs to a legacy worker.
+4. Restore the previously validated v2 API and worker together. Preserve the
+   Redis namespace, `SESSION_SECRET`, OIDC identity mapping, and retention
+   settings when retained tasks must remain recoverable.
+5. Prove `/health/live`, `/health/ready`, task creation, completion, list/read,
+   reconnect replay, and idempotent acknowledgement with synthetic data.
+6. Keep the failed candidate and Redis evidence isolated for diagnosis until
+   the recovery window closes. Revert source through a normal reviewed commit
+   or pull request; do not rewrite shared history.
+
+For a local tutorial rollback, `docker compose down` preserves the named Redis
+volume. Check out the previously validated v2 commit in a clean worktree,
+rebuild, and rerun the Compose smoke. Avoid `docker compose down --volumes`
+unless deleting all queued jobs and saved tutorial results is the explicit
+goal.
+
+To inspect the original teaching source without altering the active checkout:
+
+```sh
+git worktree add ../sample-notifier-legacy 4ec72a8
+```
+
+Treat that worktree as historical evidence, not as a runnable or deployable
+rollback artifact.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,72 @@
+# Privacy and data handling
+
+This repository is a software tutorial and production starter. It is not a
+clinical, financial, identity, or regulated-data system. Use synthetic,
+non-sensitive messages in the local lab. An adopter must perform its own data
+classification, privacy review, threat model, retention decision, and legal
+assessment before processing real data.
+
+## Data inventory
+
+| Data | Where it exists | Default behavior |
+| --- | --- | --- |
+| Task message and derived result | BullMQ job data and terminal state in Redis | Terminal jobs are configured for 24-hour age-based retention |
+| Anonymous session identifier | Signed HttpOnly, SameSite cookie | Random local identity; the browser page cannot read it |
+| Opaque owner and room keys | Queue data and Redis indexes | HMAC-derived; raw tenant and subject claims are not stored |
+| Acknowledgement timestamp | Redis | First write is retained with the task recovery window |
+| Recent-task index | Redis sorted set | Bounded on read and expires with configured retention |
+| Rate-limit counter | Redis | Expires after the configured fixed window |
+| OIDC access token and claims | Request/socket authentication memory | Validated transiently; not written to job or application state |
+
+The simulated result includes the submitted message. Do not type secrets,
+access tokens, personal data, or production payloads into the tutorial.
+Browser rendering uses `textContent`, but safe rendering does not make stored
+content appropriate to collect.
+
+## Network and logging boundary
+
+The local Compose stack publishes only the API on loopback. Redis stays on the
+container network. The application has no built-in analytics, advertising, or
+telemetry exporter. In production OIDC mode it retrieves signing keys from the
+single configured JWKS endpoint.
+
+Application logs avoid task bodies, cookies, access tokens, Redis URLs,
+credentials, certificate contents, and raw identity claims. Reverse proxies,
+container platforms, identity providers, Redis services, and observability
+agents may create their own metadata or logs; configure and review them
+separately.
+
+## Retention and deletion
+
+`TASK_RETENTION_SECONDS` applies to terminal BullMQ jobs, recent-task indexes,
+and acknowledgements. It defaults to 24 hours and accepts 5 minutes through 30
+days. Age-based queue cleanup can be lazy, and queued or active work is not a
+terminal retention promise. Backups, replicas, logs, browser storage, and
+infrastructure snapshots are outside the application deletion path.
+
+The local named Redis volume survives `docker compose down`. Running
+`docker compose down --volumes` intentionally deletes queued work and saved
+results from that local volume and cannot be undone through this application.
+
+An adopter must define and test:
+
+- the data owner and purpose for every task field;
+- minimum necessary collection and message bounds;
+- deletion behavior for queued, active, terminal, acknowledged, and failed
+  work;
+- backup, replica, and log expiration;
+- subject-access or deletion workflows where applicable; and
+- incident response and notification duties.
+
+An acknowledgement proves only that an authorized client called the endpoint.
+It is not evidence that a person read, understood, or acted on a notification.
+
+## Privacy-safe verification
+
+Use generated identifiers and synthetic messages for tests, screenshots, logs,
+and bug reports. Never attach Redis dumps, access tokens, cookies, private
+certificates, real task payloads, or environment files to a public issue.
+
+See [the security policy](../SECURITY.md), [production guide](production.md),
+and [migration and rollback guide](migration.md) for the surrounding
+operational controls.

--- a/test/unit/documentation.test.js
+++ b/test/unit/documentation.test.js
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { access, readFile, readdir } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import test from "node:test";
+
+const repositoryRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+
+const requiredDocuments = [
+  "README.md",
+  "CHANGELOG.md",
+  "SECURITY.md",
+  "docs/architecture.md",
+  "docs/migration.md",
+  "docs/privacy.md",
+  "docs/production.md",
+  "docs/tutorial.md",
+];
+
+async function readDocument(name) {
+  return readFile(path.join(repositoryRoot, name), "utf8");
+}
+
+test("adoption documentation includes migration, rollback, privacy, and security boundaries", async () => {
+  const [readme, migration, privacy, security, changelog] = await Promise.all([
+    readDocument("README.md"),
+    readDocument("docs/migration.md"),
+    readDocument("docs/privacy.md"),
+    readDocument("SECURITY.md"),
+    readDocument("CHANGELOG.md"),
+  ]);
+
+  for (const link of [
+    "docs/migration.md",
+    "docs/privacy.md",
+    "SECURITY.md",
+    "CHANGELOG.md",
+  ]) {
+    assert.match(readme, new RegExp(`\\(${link.replace(".", "\\.")}\\)`));
+  }
+
+  assert.match(migration, /^## Compatibility boundary$/m);
+  assert.match(migration, /^## Cutover$/m);
+  assert.match(migration, /^## Rollback$/m);
+  assert.match(migration, /Do \*\*not\*\* roll production traffic back to the 2016 stack/);
+  assert.match(privacy, /^## Data inventory$/m);
+  assert.match(privacy, /Use synthetic,\s+non-sensitive messages/s);
+  assert.match(security, /^## Report a vulnerability$/m);
+  assert.match(changelog, /^## 2\.0\.0 - 2026-07-27$/m);
+});
+
+test("local links in repository Markdown resolve", async () => {
+  const docsDirectory = path.join(repositoryRoot, "docs");
+  const documentationFiles = [
+    "README.md",
+    "CHANGELOG.md",
+    "SECURITY.md",
+    ...(await readdir(docsDirectory))
+      .filter((name) => name.endsWith(".md"))
+      .map((name) => path.join("docs", name)),
+  ];
+  const linkPattern = /!?\[[^\]]*]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+
+  for (const document of documentationFiles) {
+    const body = await readDocument(document);
+    for (const match of body.matchAll(linkPattern)) {
+      const target = match[1];
+      if (
+        target.startsWith("#") ||
+        /^[a-z][a-z0-9+.-]*:/i.test(target)
+      ) {
+        continue;
+      }
+
+      const decodedPath = decodeURIComponent(target.split(/[?#]/, 1)[0]);
+      const resolved = decodedPath.startsWith("/")
+        ? path.join(repositoryRoot, decodedPath)
+        : path.resolve(repositoryRoot, path.dirname(document), decodedPath);
+      await assert.doesNotReject(
+        access(resolved),
+        `${document} links to missing local path ${target}`,
+      );
+    }
+  }
+
+  assert.deepEqual(
+    [...new Set(requiredDocuments)].sort(),
+    requiredDocuments.slice().sort(),
+  );
+  await Promise.all(
+    requiredDocuments.map((document) =>
+      assert.doesNotReject(
+        access(path.join(repositoryRoot, document)),
+        `required document is missing: ${document}`,
+      ),
+    ),
+  );
+});


### PR DESCRIPTION
## What changed

- add a migration guide that maps the 2016 socket-ID/Pub/Sub contracts to the
  v2 durable task, stable identity, recovery, and acknowledgement contracts
- add a production-safe cutover and rollback procedure that explicitly forbids
  downgrading v2 jobs to the lossy legacy stack
- add dedicated privacy/data-handling guidance, a security policy, and a
  changelog
- link the adoption documents from the README
- add a unit contract that checks required handoff sections and all
  repository-local Markdown links
- include documentation in the test-stage build context while keeping it out
  of the runtime image

## Why

The functional Node 24/BullMQ replacement and the recovered browser safeguard
are already on `master` through PRs #2–#4. The remaining requested handoff gaps
were migration, rollback, changelog, and explicit privacy/security
documentation. This focused follow-up closes those gaps without changing
dependencies or runtime code.

The historical task-local commit `f56898d` is not reachable on GitHub, but its
exact `tutorial-assets.test.js` content is present in commit `3bbf4f0` and
merged through PR #4.

## Validation

Exact candidate: `b49dacd594d5f86a5018e8da4217e557dd5138d3`

- `npm test` — 28/28 passed
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- `docker compose --profile test run --build --rm -T test` — 28
  unit/documentation/browser-contract tests and 3 Redis integration tests
  passed under the pinned Node 24 test image
- browser runtime smoke on loopback port 3011 — queued → running → completed;
  acknowledgement became durable `Seen` state after reload; no console
  warnings/errors
- API container — non-root, read-only, all capabilities dropped,
  loopback-only port; docs absent from runtime image
- API and worker graceful stop — exit 0
- `docker compose config --quiet`, `git diff --check`, local-link validation,
  and scoped credential-pattern scan passed

## Delivery boundary

There are no deployment environments, Pages site, deployment records, or
release jobs in this repository. CI is test-only with read-only contents
permission. This PR does not deploy, publish a package or release, migrate
data, use private data, or create paid resources.
